### PR TITLE
feat: wallet integration guide, quote caching, and paginated SDK helper

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
+    "node-cache": "^5.1.2",
     "pino": "^8.17.2",
     "pino-pretty": "^10.3.1",
     "zod": "^3.22.4"

--- a/api/src/__tests__/api.e2e.test.ts
+++ b/api/src/__tests__/api.e2e.test.ts
@@ -137,6 +137,19 @@ describe('API E2E', () => {
     expect(res.body.error).toBe('validation_error');
   });
 
+  it('GET /api/v1/quote returns identical response on repeated call (cache hit)', async () => {
+    const query = {
+      sourceAsset: 'XLM',
+      amount: '9999',
+      targetAddress: 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+    };
+    const res1 = await request(app).get('/api/v1/quote').query(query).set('X-API-Key', 'test-api-key-123');
+    const res2 = await request(app).get('/api/v1/quote').query(query).set('X-API-Key', 'test-api-key-123');
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(res1.body).toEqual(res2.body);
+  });
+
   it('GET /api/v1/status/:txHash returns 400 for invalid hash', async () => {
     const res = await request(app)
       .get('/api/v1/status/short-hash')

--- a/api/src/routes/quote.ts
+++ b/api/src/routes/quote.ts
@@ -1,8 +1,11 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
+import NodeCache from 'node-cache';
 import { sorobanService } from '../services/soroban';
 
 export const quoteRouter = Router();
+
+const quoteCache = new NodeCache({ stdTTL: 30 });
 
 const stellarAddressRegex = /^[GC][A-Z2-7]{55}$/;
 
@@ -15,11 +18,18 @@ const getQuoteSchema = z.object({
 quoteRouter.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const params = getQuoteSchema.parse(req.query);
+    const cacheKey = `${params.sourceAsset}:${params.amount}:${params.targetAddress}`;
+    const cached = quoteCache.get(cacheKey);
+    if (cached !== undefined) {
+      res.json(cached);
+      return;
+    }
     const quote = await sorobanService.getQuote(
       params.sourceAsset,
       params.amount,
       params.targetAddress,
     );
+    quoteCache.set(cacheKey, quote);
     res.json(quote);
   } catch (err) {
     next(err);

--- a/docs/wallet-integration.md
+++ b/docs/wallet-integration.md
@@ -1,0 +1,244 @@
+# Wallet Integration Guide
+
+This guide shows how wallets and dApps integrate the C-Address Onboarding Bridge SDK to fund Soroban smart accounts (C-addresses) directly — without requiring the end user to have a traditional G-address first.
+
+## Table of Contents
+
+- [Address Detection](#address-detection)
+- [Getting Started](#getting-started)
+- [Funding Flows](#funding-flows)
+  - [1. G-Address → C-Address](#1-g-address--c-address)
+  - [2. CEX Withdrawal → C-Address](#2-cex-withdrawal--c-address)
+  - [3. Credit Card → C-Address](#3-credit-card--c-address)
+- [Error Handling](#error-handling)
+- [Contract Addresses](#contract-addresses)
+
+---
+
+## Address Detection
+
+Before initiating any funding flow, detect whether the recipient is a C-address (Soroban smart account) or a traditional G-address so you can route correctly.
+
+```typescript
+import { utils } from '@c-address-bridge/sdk';
+
+const recipient = 'C...';
+
+if (utils.isCAddress(recipient)) {
+  // Use the bridge to fund a Soroban smart account
+} else if (utils.isGAddress(recipient)) {
+  // Use a standard Stellar payment operation
+} else {
+  throw new Error('Invalid address');
+}
+```
+
+C-addresses start with `C` and are 56 characters long (base32). G-addresses start with `G` and follow the same format. `utils.isValidStellarAddress` accepts both.
+
+---
+
+## Getting Started
+
+Install the SDK:
+
+```bash
+npm install @c-address-bridge/sdk
+```
+
+Create a client with your API key:
+
+```typescript
+import { BridgeClient } from '@c-address-bridge/sdk';
+
+const client = new BridgeClient({
+  baseUrl: 'https://api.bridge.example.com',
+  apiKey: 'your-api-key',   // sent as X-API-Key on every request
+});
+```
+
+All endpoints require an API key. Contact the bridge operator to obtain one.
+
+---
+
+## Funding Flows
+
+### 1. G-Address → C-Address
+
+Use when a sender with an existing Stellar G-address wants to fund a Soroban smart account.
+
+#### Step 1 — Get a quote
+
+```typescript
+const quote = await client.getQuote({
+  sourceAsset: 'XLM',
+  amount: '10000000',        // 1 XLM in stroops
+  targetAddress: 'C...',
+});
+
+console.log(`Fee: ${quote.estimatedFee} stroops (${quote.feeBps} bps)`);
+console.log(`Recipient receives: ${quote.expectedReceive} stroops`);
+```
+
+Quotes are cached for 30 seconds server-side, so polling is safe.
+
+#### Step 2 — Prepare the funding transaction
+
+```typescript
+const prepared = await client.prepareFundingTransaction({
+  sourceAddress: 'G...',
+  targetAddress: 'C...',
+  tokenAddress: 'CC...',     // SEP-41 token contract address
+  amount: '10000000',
+  memo: 'onboarding',        // optional
+});
+
+// prepared.instruction is a base64 XDR transaction envelope ready to sign
+```
+
+#### Step 3 — Sign in the wallet
+
+Pass `prepared.instruction` to the user's wallet for signing. The exact API depends on the wallet SDK:
+
+```typescript
+// Generic example — replace with your wallet's signing API
+const signedXdr = await wallet.signTransaction(prepared.instruction, {
+  networkPassphrase: 'Test SDF Network ; September 2015',
+});
+```
+
+#### Step 4 — Submit the signed transaction
+
+```typescript
+const result = await client.submitSignedXdr({ signedXdr });
+
+console.log(`Status: ${result.status}`);   // 'pending' | 'success' | 'failed'
+console.log(`Hash: ${result.hash}`);
+```
+
+#### Step 5 — Poll for confirmation (optional)
+
+```typescript
+const status = await client.getStatus(result.hash);
+console.log(status.status); // 'pending' | 'success' | 'failed'
+```
+
+---
+
+### 2. CEX Withdrawal → C-Address
+
+Use when the user is withdrawing from a centralised exchange directly to a C-address.
+
+```typescript
+const result = await client.routeCexWithdrawal({
+  exchange: 'binance',        // 'binance' | 'coinbase' | 'kraken' | 'generic'
+  sourceAsset: 'XLM',
+  amount: '10000000',
+  targetCAddress: 'C...',
+  targetNetwork: 'stellar',
+  memo: 'bridge:binance:ABCD1234',  // used to correlate the on-chain withdrawal
+});
+
+console.log(`Withdrawal ID: ${result.withdrawalId}`);
+console.log(`ETA: ${result.estimatedArrival}`);
+```
+
+The bridge operator configures the exchange API credentials. The memo format `bridge:{exchange}:{suffix}` allows the bridge to match incoming deposits to withdrawal requests.
+
+---
+
+### 3. Credit Card → C-Address
+
+Let users buy crypto with a card and land directly in a C-address via Moonpay or Transak.
+
+#### Moonpay
+
+```typescript
+const moonpay = await client.createMoonpayUrl({
+  walletAddress: 'C...',
+  currencyCode: 'xlm',
+  walletNetwork: 'stellar',
+  baseCurrencyAmount: 100,
+  baseCurrencyCode: 'USD',
+  email: 'user@example.com',  // optional, pre-fills the Moonpay form
+});
+
+window.open(moonpay.url);
+```
+
+#### Transak
+
+```typescript
+const transak = await client.createTransakUrl({
+  walletAddress: 'C...',
+  network: 'stellar',
+  fiatCurrency: 'USD',
+  cryptoCurrency: 'XLM',
+  fiatAmount: 100,
+  redirectURL: 'https://your-app.com/success',
+});
+
+window.open(transak.url);
+```
+
+After the user completes the purchase, the provider sends a webhook to the bridge, which routes the funds to the C-address automatically.
+
+---
+
+## Error Handling
+
+All `BridgeClient` methods throw a native `Error` on failure. The message comes from the API response body when available.
+
+```typescript
+import { BridgeClient } from '@c-address-bridge/sdk';
+
+const client = new BridgeClient({ baseUrl: '...', apiKey: '...' });
+
+try {
+  const quote = await client.getQuote({
+    sourceAsset: 'XLM',
+    amount: '10000000',
+    targetAddress: 'C...',
+  });
+} catch (err) {
+  if (err instanceof Error) {
+    switch (true) {
+      case err.message === 'unauthorized':
+        // Prompt user to re-authenticate or contact support
+        break;
+      case err.message.startsWith('validation_error'):
+        // Show inline field error
+        break;
+      default:
+        // Generic fallback
+        console.error('Bridge error:', err.message);
+    }
+  }
+}
+```
+
+Common error messages:
+
+| Message | Cause |
+|---------|-------|
+| `unauthorized` | Missing or invalid `X-API-Key` header |
+| `validation_error` | Invalid query parameter (bad address, missing field, etc.) |
+| `request failed: ...` | HTTP-level failure or network error |
+
+Requests time out after **30 seconds**. Implement retry logic with exponential backoff in your application as needed.
+
+---
+
+## Contract Addresses
+
+| Network | Contract ID |
+|---------|-------------|
+| Testnet | `CD3YJ3M7PQ5PF7XT4NL2AX7XINJWXZ7TAIHY36NI6NWW2UABAAOAFAIC` |
+| Mainnet | TBD |
+
+**Testnet**
+- RPC URL: `https://soroban-rpc.testnet.stellar.org`
+- Network passphrase: `Test SDF Network ; September 2015`
+
+**Mainnet**
+- RPC URL: `https://soroban-rpc.stellar.org`
+- Network passphrase: `Public Global Stellar Network ; September 2015`

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
         "helmet": "^7.1.0",
+        "node-cache": "^5.1.2",
         "pino": "^8.17.2",
         "pino-pretty": "^10.3.1",
         "zod": "^3.22.4"
@@ -2018,6 +2019,15 @@
         "node": "*"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3737,6 +3747,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/npm-run-path": {

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -11,6 +11,8 @@ import {
   TransakWidgetResult,
   CexWithdrawalParams,
   CexWithdrawalResult,
+  PaginatedRequestParams,
+  PaginatedResponse,
 } from './types';
 
 export interface BridgeClientConfig {
@@ -67,6 +69,14 @@ export class BridgeClient {
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  async requestPaginated<T>(path: string, params?: PaginatedRequestParams): Promise<PaginatedResponse<T>> {
+    const queryParams: Record<string, string | undefined> = {};
+    if (params?.cursor !== undefined) queryParams['cursor'] = params.cursor;
+    if (params?.limit !== undefined) queryParams['limit'] = String(params.limit);
+    if (params?.offset !== undefined) queryParams['offset'] = String(params.offset);
+    return this.request<PaginatedResponse<T>>('GET', path, undefined, queryParams);
   }
 
   async getQuote(params: QuoteParams): Promise<Quote> {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -83,3 +83,15 @@ export interface BridgeClientConfig {
   baseUrl: string;
   apiKey?: string;
 }
+
+export interface PaginatedRequestParams {
+  cursor?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}

--- a/sdk/tests/bridge.test.ts
+++ b/sdk/tests/bridge.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BridgeClient } from '../src/bridge';
+import { PaginatedResponse } from '../src/types';
 import { calculateFee, calculateReceiveAmount, isValidStellarAddress, isCAddress, isGAddress } from '../src/utils';
 
 const VALID_C_ADDR = 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
@@ -19,6 +20,60 @@ describe('BridgeClient', () => {
   it('creates a client with api key', () => {
     const client = new BridgeClient({ baseUrl: 'http://localhost:3001', apiKey: 'test-key' });
     expect(client).toBeInstanceOf(BridgeClient);
+  });
+});
+
+describe('BridgeClient.requestPaginated', () => {
+  let client: BridgeClient;
+
+  beforeEach(() => {
+    client = new BridgeClient({ baseUrl: 'http://localhost:3001', apiKey: 'test-key' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a paginated response with cursor and limit', async () => {
+    const mockPage: PaginatedResponse<{ id: string }> = {
+      data: [{ id: 'a' }, { id: 'b' }],
+      nextCursor: 'cursor-2',
+      hasMore: true,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockPage),
+    }));
+
+    const result = await client.requestPaginated<{ id: string }>('/api/v1/txns', {
+      limit: 2,
+      cursor: 'cursor-1',
+    });
+
+    expect(result).toEqual(mockPage);
+    const calledUrl: string = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(calledUrl).toContain('limit=2');
+    expect(calledUrl).toContain('cursor=cursor-1');
+  });
+
+  it('handles the last page with hasMore false and no nextCursor', async () => {
+    const mockPage: PaginatedResponse<{ id: string }> = {
+      data: [{ id: 'z' }],
+      nextCursor: null,
+      hasMore: false,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockPage),
+    }));
+
+    const result = await client.requestPaginated<{ id: string }>('/api/v1/txns', { offset: 10, limit: 5 });
+
+    expect(result.hasMore).toBe(false);
+    expect(result.nextCursor).toBeNull();
+    const calledUrl: string = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(calledUrl).toContain('offset=10');
+    expect(calledUrl).toContain('limit=5');
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds wallet integration documentation covering all 3 funding flows (closes #1)
- soroban-sdk is already at v26.0.1 and the 4 token-transfer tests have no `#[ignore]` attributes — requirements for closes #2 are already met in the codebase
- Adds 30-second in-memory cache to `GET /api/v1/quote` using `node-cache` (closes #3)
- Adds `PaginatedRequestParams`, `PaginatedResponse<T>`, and `BridgeClient.requestPaginated` to the SDK (closes #4)

## Changes per issue

**#1 — Wallet integration guide (`docs/wallet-integration.md`)**
- Documents all 3 funding flows: G-address → C-address, CEX withdrawal → C-address, credit card → C-address
- Shows `BridgeClient` setup with API key authentication
- Covers the prepare-and-submit flow (`/fund/prepare` → wallet sign → `/fund`)
- Includes error handling patterns and a table of common errors
- Documents C-address vs G-address detection via `utils.isCAddress()`
- References testnet contract address and RPC endpoints

**#2 — soroban-sdk upgrade and ignore removal**
- `Cargo.toml` already specifies `soroban-sdk = "26.0.1"` (satisfies ≥ 22)
- All 4 previously-skipped tests (`test_fund_with_zero_fee`, `test_withdraw_fees`, `test_route_from_exchange`, and the renamed `test_fund_c_address_tracks_fees`) are present in `test.rs` without `#[ignore]`
- No changes required

**#3 — Quote response caching (`api/src/routes/quote.ts`)**
- Added `node-cache` as a dependency (TTL = 30 s)
- Cache key: `sourceAsset:amount:targetAddress`
- Added e2e test asserting identical responses on repeated calls with the same params

**#4 — Paginated request helper (`sdk/src/bridge.ts`, `sdk/src/types.ts`)**
- Added `PaginatedRequestParams` interface (`cursor`, `limit`, `offset`)
- Added `PaginatedResponse<T>` interface (`data`, `nextCursor`, `hasMore`)
- Added `BridgeClient.requestPaginated<T>(path, params?)` method
- Added two unit tests using a mock fetch (cursor+limit params, last-page case)

Closes #1
Closes #2
Closes #3
Closes #4