### PR TITLE
feat: add bundle size optimization, analysis, and CI enforcement (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Bundle size check
+        run: npm run bundle:check
+
+      - name: Upload bundle analysis report
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-bundle-analysis
+          path: sdk/dist/bundle/meta.json
+          retention-days: 30
+
       - name: Verify strict consumer build
         run: npm run build:strict-consumer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -405,6 +405,7 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.0.1.tgz",
       "integrity": "sha512-gKEGSD8dlUoWFGJJ4I4Q5bDtfB7yJwGfpgA2DVn1G1TzlUSN5n4fzzcGpLf5fS+QhR7tB/niydUiFRQ2zrjVrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bull-board/api": "8.0.1"
       }
@@ -2098,6 +2099,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3132,6 +3134,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3351,6 +3354,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4803,6 +4807,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
       "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
@@ -4900,6 +4905,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6148,6 +6154,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6925,6 +6932,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6935,9 +6943,440 @@
       "devDependencies": {
         "@types/node": "^20.11.5",
         "@typescript-eslint/parser": "^8.62.0",
+        "esbuild": "^0.21.5",
         "eslint": "^8.56.0",
         "typescript": "^5.3.3",
         "vitest": "^1.2.2"
+      }
+    },
+    "sdk/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "sdk/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     }
   }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -3,16 +3,54 @@
   "version": "0.1.0",
   "private": true,
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./core": {
+      "import": "./dist/esm/core.js",
+      "require": "./dist/core.js",
+      "types": "./dist/core.d.ts"
+    },
+    "./offline": {
+      "import": "./dist/esm/offline.js",
+      "require": "./dist/offline.js",
+      "types": "./dist/offline.d.ts"
+    },
+    "./events": {
+      "import": "./dist/esm/events.js",
+      "require": "./dist/events.js",
+      "types": "./dist/events.d.ts"
+    },
+    "./telemetry": {
+      "import": "./dist/esm/telemetry.js",
+      "require": "./dist/telemetry.js",
+      "types": "./dist/telemetry.d.ts"
+    },
+    "./pagination": {
+      "import": "./dist/esm/pagination.js",
+      "require": "./dist/pagination.js",
+      "types": "./dist/pagination.d.ts"
+    }
+  },
+  "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig.esm.json && tsc -p tsconfig.umd.json",
     "build:strict-consumer": "tsc -p tests/fixtures/strict-consumer/tsconfig.json",
+    "build:bundle": "node scripts/build-bundle.mjs",
+    "bundle:analyze": "node scripts/build-bundle.mjs --analyze",
+    "bundle:check": "npm run build:bundle && node scripts/check-bundle-size.mjs",
     "test": "vitest run",
     "lint": "eslint --ext .ts src/"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",
     "@typescript-eslint/parser": "^8.62.0",
+    "esbuild": "^0.21.5",
     "eslint": "^8.56.0",
     "typescript": "^5.3.3",
     "vitest": "^1.2.2"

--- a/sdk/scripts/build-bundle.mjs
+++ b/sdk/scripts/build-bundle.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Builds SDK bundles with esbuild for browser consumers.
+ * Generates minified ESM bundles and a metafile for size analysis.
+ *
+ * Usage:
+ *   node scripts/build-bundle.mjs           # build only
+ *   node scripts/build-bundle.mjs --analyze # build + print analysis
+ */
+
+import esbuild from 'esbuild';
+import { gzipSync } from 'zlib';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const outDir = resolve(root, 'dist', 'bundle');
+const analyze = process.argv.includes('--analyze');
+
+mkdirSync(outDir, { recursive: true });
+
+const sharedOptions = {
+  bundle: true,
+  minify: true,
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2020',
+  treeShaking: true,
+  legalComments: 'none',
+};
+
+/** [entryPoint, outFile, label] */
+const bundles = [
+  ['src/core.ts',       'core.min.js',       'core'],
+  ['src/index.ts',      'index.min.js',      'full'],
+  ['src/offline.ts',    'offline.min.js',    'offline'],
+  ['src/events.ts',     'events.min.js',     'events'],
+  ['src/telemetry.ts',  'telemetry.min.js',  'telemetry'],
+  ['src/pagination.ts', 'pagination.min.js', 'pagination'],
+];
+
+const results = [];
+let fullMetafile = null;
+
+for (const [entry, outFile, label] of bundles) {
+  const needMeta = entry === 'src/index.ts';
+  const result = await esbuild.build({
+    ...sharedOptions,
+    entryPoints: [resolve(root, entry)],
+    outfile: resolve(outDir, outFile),
+    metafile: needMeta,
+  });
+
+  if (result.errors.length > 0) {
+    console.error(`esbuild errors in ${label}:`);
+    result.errors.forEach((e) => console.error(' ', e.text));
+    process.exit(1);
+  }
+
+  if (needMeta) fullMetafile = result.metafile;
+
+  const bytes = readFileSync(resolve(outDir, outFile));
+  const gz = gzipSync(bytes, { level: 9 });
+  results.push({ label, raw: bytes.length, gz: gz.length });
+}
+
+if (fullMetafile) {
+  writeFileSync(resolve(outDir, 'meta.json'), JSON.stringify(fullMetafile, null, 2));
+
+  if (analyze) {
+    const text = await esbuild.analyzeMetafile(fullMetafile, { verbose: false });
+    console.log('\n=== esbuild bundle analysis (full) ===');
+    console.log(text);
+  }
+}
+
+console.log('\nBundle sizes:');
+console.log('─'.repeat(52));
+console.log('  Module        │  Raw (KB)  │  Gzip (KB)');
+console.log('─'.repeat(52));
+for (const { label, raw, gz } of results) {
+  const rawKb = (raw / 1024).toFixed(2).padStart(9);
+  const gzKb  = (gz  / 1024).toFixed(2).padStart(10);
+  console.log(`  ${label.padEnd(14)}│${rawKb}  │${gzKb}`);
+}
+console.log('─'.repeat(52));
+console.log('\nAnalysis report: dist/bundle/meta.json');
+console.log('View at: https://esbuild.github.io/analyze/');

--- a/sdk/scripts/check-bundle-size.mjs
+++ b/sdk/scripts/check-bundle-size.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Bundle size budget check.
+ * Reads dist/bundle/*.min.js, gzips each, and fails if any budget is exceeded.
+ *
+ * Budgets (gzipped):
+ *   core        8 KB   — minimum viable SDK (BridgeClient + types)
+ *   full index  15 KB  — everything including optional modules
+ *   offline      5 KB  — OfflineQueue + OfflineBridgeClient
+ *   events       4 KB  — BridgeEventEmitter
+ *   telemetry    3 KB  — TelemetryClient
+ *   pagination   2 KB  — PaginationHelper helpers
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { gzipSync } from 'zlib';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = resolve(__dirname, '..', 'dist', 'bundle');
+
+const BUDGETS_KB = {
+  'core.min.js':       8,
+  'index.min.js':     15,
+  'offline.min.js':    5,
+  'events.min.js':     4,
+  'telemetry.min.js':  3,
+  'pagination.min.js': 2,
+};
+
+let failed = false;
+
+console.log('\nBundle size check:');
+console.log('─'.repeat(60));
+console.log('  File                │  Gzip (KB)  │  Budget (KB)  │  Status');
+console.log('─'.repeat(60));
+
+for (const [file, budgetKb] of Object.entries(BUDGETS_KB)) {
+  const filePath = resolve(outDir, file);
+
+  if (!existsSync(filePath)) {
+    console.error(`  ${file}: NOT FOUND — run "npm run build:bundle" first`);
+    failed = true;
+    continue;
+  }
+
+  const raw = readFileSync(filePath);
+  const gz = gzipSync(raw, { level: 9 });
+  const gzKb = gz.length / 1024;
+  const pass = gzKb <= budgetKb;
+  const status = pass ? 'PASS' : `FAIL (+${(gzKb - budgetKb).toFixed(2)} KB over)`;
+
+  const gzStr     = gzKb.toFixed(2).padStart(8);
+  const budgetStr = budgetKb.toFixed(2).padStart(12);
+  console.log(`  ${file.padEnd(20)}│${gzStr}     │${budgetStr}     │  ${status}`);
+
+  if (!pass) failed = true;
+}
+
+console.log('─'.repeat(60));
+
+if (failed) {
+  console.error('\nBundle size budget EXCEEDED. Reduce bundle size or update budgets in scripts/check-bundle-size.mjs.\n');
+  process.exit(1);
+} else {
+  console.log('\nAll bundles within budget.\n');
+}

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -14,15 +14,25 @@ import {
   PaginatedRequestParams,
   PaginatedResponse,
   RequestParams,
+  RequestOptions,
   FundingPrepareResult,
+  HttpMethod,
 } from './types';
 import { SimpleCache } from './cache';
 import { TelemetryClient } from './telemetry';
 
 const REQUEST_TIMEOUT_MS = 30_000;
-type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type { BridgeClientConfig } from './types';
+import type { BridgeClientConfig } from './types';
 
 export class BridgeClient {
+  private readonly config: BridgeClientConfig;
+  private readonly cache: SimpleCache;
+  private readonly telemetry: TelemetryClient;
+  private readonly metrics = { totalRequests: 0 };
+  private readonly defaultTimeout: number;
+  private readonly fundSubmissionTimeout: number;
   private baseUrl: string;
   private apiKey?: string;
   private retryConfig: Required<NonNullable<BridgeClientConfig['retry']>>;
@@ -31,6 +41,10 @@ export class BridgeClient {
     this.config = config;
     this.baseUrl = config.baseUrl.replace(/\/+$/, '');
     this.apiKey = config.apiKey;
+    this.defaultTimeout = REQUEST_TIMEOUT_MS;
+    this.fundSubmissionTimeout = REQUEST_TIMEOUT_MS * 2;
+    this.cache = new SimpleCache({ maxEntries: config.cache?.maxEntries });
+    this.telemetry = new TelemetryClient(config.telemetry ?? {});
     this.retryConfig = {
       maxRetries: config.retry?.maxRetries ?? 3,
       baseDelayMs: config.retry?.baseDelayMs ?? 100,
@@ -56,14 +70,14 @@ export class BridgeClient {
     return Math.max(0, capped + jitter);
   }
 
-  private async request<T>(
+  protected async request<T>(
     method: HttpMethod,
     path: string,
     body?: Record<string, unknown>,
     params?: RequestParams,
+    options?: RequestOptions,
   ): Promise<T> {
     const timeoutMs = options?.timeout ?? this.defaultTimeout;
-    const startTime = Date.now();
     this.metrics.totalRequests++;
 
     const url = new URL(`${this.baseUrl}${path}`);
@@ -83,7 +97,7 @@ export class BridgeClient {
 
     while (true) {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
       try {
         const res = await fetch(url.toString(), {
@@ -122,7 +136,6 @@ export class BridgeClient {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-  }
   }
 
   async requestPaginated<T>(path: string, params?: PaginatedRequestParams): Promise<PaginatedResponse<T>> {

--- a/sdk/src/core.ts
+++ b/sdk/src/core.ts
@@ -1,0 +1,23 @@
+export { BridgeClient, type BridgeClientConfig } from './bridge';
+export type {
+  BridgeStatus,
+  RequestParams,
+  RequestValue,
+  FundingPrepareResult,
+  QuoteParams,
+  Quote,
+  FundParams,
+  FundWithXdrParams,
+  FundingResult,
+  TransactionStatus,
+  MoonpayWidgetParams,
+  MoonpayWidgetResult,
+  TransakWidgetParams,
+  TransakWidgetResult,
+  CexWithdrawalParams,
+  CexWithdrawalResult,
+  PaginatedRequestParams,
+  PaginatedResponse,
+} from './types';
+export * as utils from './utils';
+export { TimeoutError } from './errors';

--- a/sdk/src/offline.ts
+++ b/sdk/src/offline.ts
@@ -1,4 +1,4 @@
-import { QueueEntry, OfflineQueueOptions, StorageAdapter, RequestOptions } from './types';
+import { QueueEntry, OfflineQueueOptions, StorageAdapter, RequestOptions, HttpMethod } from './types';
 import { BridgeClient, BridgeClientConfig } from './bridge';
 import { OfflineError, QueueFullError, TimeoutError } from './errors';
 
@@ -148,7 +148,7 @@ export class OfflineBridgeClient extends BridgeClient {
   }
 
   protected override async request<T>(
-    method: string,
+    method: HttpMethod,
     path: string,
     body?: Record<string, unknown>,
     params?: Record<string, string | undefined>,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,6 +1,11 @@
 export type BridgeStatus = 'pending' | 'success' | 'failed';
 export type RequestValue = string | number | boolean | undefined;
 export type RequestParams = Record<string, RequestValue>;
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface RequestOptions {
+  timeout?: number;
+}
 
 export interface QuoteParams {
   sourceAsset: string;
@@ -94,6 +99,18 @@ export interface BridgeClientConfig {
     jitterMs?: number;
     logger?: Pick<Console, 'debug'>;
   };
+  cache?: {
+    quoteTtlMs?: number;
+    statusTtlMs?: number;
+    healthTtlMs?: number;
+    staleWhileRevalidate?: boolean;
+    maxEntries?: number;
+  };
+  telemetry?: {
+    endpoint?: string;
+    enabled?: boolean;
+    intervalMs?: number;
+  };
 }
 
 export interface PaginatedRequestParams {
@@ -112,4 +129,78 @@ export interface FundingPrepareResult {
   instruction: string;
   simulation: Record<string, string>;
   params: FundParams;
+}
+
+// Pagination helpers
+
+export interface AutoPaginateOptions {
+  pageSize?: number;
+  throttleMs?: number;
+  concurrency?: number;
+  signal?: AbortSignal;
+}
+
+export type PageFetcher<T> = (params: PaginatedRequestParams) => Promise<PaginatedResponse<T>>;
+
+// Offline queue
+
+export interface StorageAdapter {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  remove(key: string): Promise<void>;
+}
+
+export interface QueueEntry {
+  id: string;
+  timestamp: string;
+  retryCount: number;
+  method: HttpMethod;
+  path: string;
+  body?: Record<string, unknown>;
+  params?: Record<string, string | undefined>;
+}
+
+export interface OfflineQueueOptions {
+  maxSize?: number;
+  storageAdapter?: StorageAdapter;
+  healthCheckIntervalMs?: number;
+  autoQueue?: boolean;
+  healthCheckPath?: string;
+}
+
+// Event emitter
+
+export type BridgeEventType =
+  | 'transaction:pending'
+  | 'transaction:success'
+  | 'transaction:failed'
+  | 'transaction:status:changed'
+  | 'error'
+  | 'online'
+  | 'offline'
+  | 'reconnecting';
+
+export interface BridgeEventDataMap {
+  'transaction:pending': { txHash: string; status: TransactionStatus };
+  'transaction:success': { txHash: string; status: TransactionStatus };
+  'transaction:failed': { txHash: string; status: TransactionStatus; error?: string };
+  'transaction:status:changed': { txHash: string; status: TransactionStatus; previousStatus: string };
+  'error': { message: string; error: unknown };
+  'online': { at: string };
+  'offline': { at: string };
+  'reconnecting': { attempt: number; at: string };
+}
+
+export interface BridgeEvent<K extends BridgeEventType = BridgeEventType> {
+  type: K;
+  data: K extends keyof BridgeEventDataMap ? BridgeEventDataMap[K] : never;
+  timestamp: string;
+}
+
+export type EventHandler<K extends BridgeEventType = BridgeEventType> = (event: BridgeEvent<K>) => void;
+
+export interface EventEmitterOptions {
+  pollIntervalMs?: number;
+  historySize?: number;
+  healthCheckIntervalMs?: number;
 }


### PR DESCRIPTION
- Add esbuild bundler with tree-shaking and minification for browser consumers
- Introduce sdk/src/core.ts as a lightweight entry point (BridgeClient + types only, no optional modules)
- Add subpath exports for code splitting: ./core, ./offline, ./events, ./telemetry, ./pagination
- Add sideEffects: false to enable tree-shaking by downstream bundlers
- Add scripts/build-bundle.mjs: builds 6 minified ESM bundles and writes dist/bundle/meta.json for esbuild analyzer
- Add scripts/check-bundle-size.mjs: gzip-checks each bundle against a per-module budget and fails CI if exceeded
- Add bundle size check step and analysis artifact upload to CI workflow
- Fix pre-existing structural bug in bridge.ts (extra } closing class body prematurely)
- Add missing type definitions to types.ts (HttpMethod, RequestOptions, QueueEntry, OfflineQueueOptions, StorageAdapter, BridgeEventType, BridgeEvent, BridgeEventDataMap, EventHandler, EventEmitterOptions, AutoPaginateOptions, PageFetcher, cache/telemetry config on BridgeClientConfig)
- Fix offline.ts and bridge.ts to use shared HttpMethod type

Closes #66