### PR TITLE
feat: add Docker Compose local dev environment and setup guide

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,50 @@
+# Local dev environment — copy to .env and fill in any blanks.
+# All values here are safe defaults for the Docker Compose stack.
+# Never commit a real .env file.
+
+# ── Node ────────────────────────────────────────────────────────────────────
+NODE_ENV=development
+PORT=3001
+HOST=0.0.0.0
+LOG_LEVEL=debug
+
+# ── Database (matches docker-compose.yml postgres service) ──────────────────
+DATABASE_URL=postgres://bridge:bridge@localhost:5432/bridge
+
+# ── Redis (matches docker-compose.yml redis service) ────────────────────────
+REDIS_URL=redis://localhost:6379
+REDIS_QUOTE_TTL_SECONDS=30
+REDIS_STATUS_TTL_SECONDS=10
+
+# ── Soroban (local quickstart sandbox) ──────────────────────────────────────
+SOROBAN_RPC_URL=http://localhost:8000/soroban/rpc
+SOROBAN_NETWORK_PASSPHRASE=Standalone Network ; February 2017
+
+# After deploying the contract locally, paste the contract ID here:
+BRIDGE_CONTRACT_ID=
+
+BRIDGE_FEE_BPS=30
+
+# ── API auth ─────────────────────────────────────────────────────────────────
+# Comma-separated list; any value works locally
+API_KEYS=dev-api-key
+
+# ── Moonpay (leave empty to skip Moonpay routes) ────────────────────────────
+MOONPAY_API_KEY=
+MOONPAY_SECRET_KEY=
+
+# ── Transak (leave empty to skip Transak routes) ────────────────────────────
+TRANSAK_API_KEY=
+TRANSAK_ENVIRONMENT=STAGING
+
+# ── CEX ──────────────────────────────────────────────────────────────────────
+CEX_API_ENDPOINT=
+
+# ── Webhooks ──────────────────────────────────────────────────────────────────
+WEBHOOK_SIGNING_SECRET=dev-signing-secret-change-in-prod
+
+# ── Explorer ──────────────────────────────────────────────────────────────────
+STELLAR_EXPLORER=stellarexpert
+
+# ── Idempotency ───────────────────────────────────────────────────────────────
+IDEMPOTENCY_KEY_REQUIRED=false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ coverage/
 *.wasm
 .claude/
 .idea/
-.vscode/
+# Track .vscode/settings.json and extensions.json; ignore personal overrides
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 test_snapshots/
 deployments/*.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "rust-lang.rust-analyzer",
+    "ms-azuretools.vscode-docker",
+    "ms-vscode.vscode-typescript-next",
+    "bradlc.vscode-tailwindcss",
+    "redhat.vscode-yaml",
+    "tamasfe.even-better-toml",
+    "aaron-bond.better-comments",
+    "christian-kohler.path-intellisense",
+    "PKief.material-icon-theme"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,32 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.workingDirectories": [{ "mode": "auto" }],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  },
+  "rust-analyzer.cargo.features": "all",
+  "files.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/target": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/dist": true,
+    "**/target": true,
+    "package-lock.json": true,
+    "**/Cargo.lock": true
+  },
+  "docker.defaultRegistryPath": "",
+  "terminal.integrated.env.linux": {
+    "DATABASE_URL": "postgres://bridge:bridge@localhost:5432/bridge",
+    "REDIS_URL": "redis://localhost:6379"
+  }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,23 @@
+# Dev overrides: hot reload, source mounts, debug ports.
+# Applied automatically by Docker Compose when both files are present.
+services:
+  api:
+    build:
+      target: build                  # stop at build stage — no prod image needed
+    command: npm run dev -w api      # tsx watch for hot reload
+    ports:
+      - "${PORT:-3001}:3001"
+      - "9229:9229"                  # Node.js inspector
+    environment:
+      NODE_ENV: development
+      LOG_LEVEL: debug
+    volumes:
+      - .:/app
+      - /app/node_modules            # keep container's node_modules
+      - /app/api/node_modules
+      - /app/sdk/node_modules
+
+  # Expose Soroban friendbot locally for manual funding
+  soroban-quickstart:
+    ports:
+      - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "${PORT:-3001}:3001"
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      DATABASE_URL: postgres://bridge:bridge@postgres:5432/bridge
+      REDIS_URL: redis://redis:6379
+      SOROBAN_RPC_URL: ${SOROBAN_RPC_URL:-http://soroban-quickstart:8000/soroban/rpc}
+      SOROBAN_NETWORK_PASSPHRASE: ${SOROBAN_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}
+      BRIDGE_CONTRACT_ID: ${BRIDGE_CONTRACT_ID}
+      BRIDGE_FEE_BPS: ${BRIDGE_FEE_BPS:-30}
+      API_KEYS: ${API_KEYS:-dev-api-key}
+      MOONPAY_API_KEY: ${MOONPAY_API_KEY}
+      MOONPAY_SECRET_KEY: ${MOONPAY_SECRET_KEY}
+      TRANSAK_API_KEY: ${TRANSAK_API_KEY}
+      TRANSAK_ENVIRONMENT: ${TRANSAK_ENVIRONMENT:-STAGING}
+      WEBHOOK_SIGNING_SECRET: ${WEBHOOK_SIGNING_SECRET:-dev-signing-secret-change-in-prod}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: bridge
+      POSTGRES_PASSWORD: bridge
+      POSTGRES_DB: bridge
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bridge"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  soroban-quickstart:
+    image: stellar/quickstart:latest
+    ports:
+      - "8000:8000"
+    environment:
+      NETWORK: local
+    command: --local --enable-soroban-rpc
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/friendbot || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+      start_period: 30s
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -1,0 +1,365 @@
+# Developer Setup Guide
+
+This guide gets you from a fresh clone to a fully running local environment in one command.
+
+---
+
+## Quick Start
+
+```bash
+git clone https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge-Backend.git
+cd C-Address-Onboarding-Bridge-Backend
+./scripts/setup-dev.sh
+```
+
+The bootstrap script handles everything: dependencies, `.env`, Docker stack, migrations, and build. Jump to [Manual Setup](#manual-setup) if you prefer full control.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | 20+ | https://nodejs.org |
+| npm | 9+ | Bundled with Node |
+| Docker + Compose v2 | latest | https://docs.docker.com/get-docker/ |
+| Rust + `cargo` | 1.96+ | https://rustup.rs *(contract dev only)* |
+
+Verify:
+
+```bash
+node --version   # v20+
+docker compose version  # v2+
+```
+
+---
+
+## Docker Compose Stack
+
+The stack is split across two files:
+
+- `docker-compose.yml` — production-shaped services with pinned images
+- `docker-compose.override.yml` — dev overrides (source mounts, hot reload, debug port) applied automatically
+
+### Services
+
+| Service | Local port | Description |
+|---------|-----------|-------------|
+| `api` | 3001 | Express API with `tsx watch` hot reload |
+| `postgres` | 5432 | PostgreSQL 16 |
+| `redis` | 6379 | Redis 7 |
+| `soroban-quickstart` | 8000 | Stellar local sandbox + Soroban RPC |
+
+### Start / Stop
+
+```bash
+# Full stack (recommended)
+docker compose up
+
+# Detached + follow API logs only
+docker compose up -d && docker compose logs -f api
+
+# Stop and remove containers (keeps volumes)
+docker compose down
+
+# Stop and wipe volumes (full reset)
+docker compose down -v
+```
+
+### Accessing services from host
+
+```
+API:             http://localhost:3001
+API health:      http://localhost:3001/health
+Soroban RPC:     http://localhost:8000/soroban/rpc
+Friendbot:       http://localhost:8000/friendbot?addr=<G-address>
+Postgres:        postgresql://bridge:bridge@localhost:5432/bridge
+Redis:           redis://localhost:6379
+```
+
+---
+
+## Manual Setup
+
+Use this if the bootstrap script doesn't fit your workflow.
+
+### 1. Environment variables
+
+```bash
+cp .env.local.example .env
+# Edit .env — BRIDGE_CONTRACT_ID is required to run funded transactions
+```
+
+### 2. Install dependencies
+
+```bash
+npm install
+```
+
+### 3. Start backing services
+
+```bash
+docker compose up -d postgres redis soroban-quickstart
+```
+
+### 4. Run migrations
+
+```bash
+npm run migrate -w api
+```
+
+### 5. Start the API in dev mode
+
+```bash
+npm run dev -w api
+```
+
+### 6. (Optional) Deploy the Soroban contract locally
+
+```bash
+cd contracts/onboarding-bridge
+
+# Build WASM
+cargo build --target wasm32-unknown-unknown --release
+
+# Deploy to local sandbox
+soroban contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/onboarding_bridge.wasm \
+  --source <admin-secret> \
+  --rpc-url http://localhost:8000/soroban/rpc \
+  --network-passphrase "Standalone Network ; February 2017"
+
+# Initialize (paste the contract ID returned above)
+soroban contract invoke \
+  --id <contract-id> \
+  --source <admin-secret> \
+  --rpc-url http://localhost:8000/soroban/rpc \
+  --network-passphrase "Standalone Network ; February 2017" \
+  -- initialize --admin <admin-address> --fee_bps 30
+```
+
+Paste the deployed contract ID into `.env` as `BRIDGE_CONTRACT_ID`.
+
+---
+
+## Environment Variables
+
+All variables are documented in `.env.local.example`. Key ones for local dev:
+
+| Variable | Default (local) | Notes |
+|----------|----------------|-------|
+| `DATABASE_URL` | `postgres://bridge:bridge@localhost:5432/bridge` | Set automatically by Docker |
+| `REDIS_URL` | `redis://localhost:6379` | Set automatically by Docker |
+| `SOROBAN_RPC_URL` | `http://localhost:8000/soroban/rpc` | Local quickstart sandbox |
+| `SOROBAN_NETWORK_PASSPHRASE` | `Standalone Network ; February 2017` | Local sandbox passphrase |
+| `BRIDGE_CONTRACT_ID` | *(empty)* | Fill after local contract deploy |
+| `API_KEYS` | `dev-api-key` | Add `X-API-Key: dev-api-key` header |
+| `LOG_LEVEL` | `debug` | `trace \| debug \| info \| warn \| error` |
+| `IDEMPOTENCY_KEY_REQUIRED` | `false` | Set `true` to test idempotency keys |
+
+When running via `docker compose up`, the API container reads from the `environment:` block in `docker-compose.yml`. When running `npm run dev -w api` directly on your host, it reads from `.env`.
+
+---
+
+## Database Migrations
+
+```bash
+# Apply pending migrations
+npm run migrate -w api
+
+# Check migration status
+npm run migrate:status -w api
+
+# Roll back last migration
+npm run migrate:rollback -w api
+
+# Seed dev data
+npm run migrate:seed -w api
+```
+
+---
+
+## Running Tests
+
+```bash
+# All workspaces
+npm test
+
+# API unit tests only
+npm test -w api
+
+# API E2E tests (requires Docker stack running)
+npm run test:e2e -w api
+
+# SDK tests
+npm test -w sdk
+
+# Rust contract tests
+cd contracts/onboarding-bridge && cargo test
+```
+
+---
+
+## VS Code
+
+Install recommended extensions when prompted, or manually:
+
+```
+Ctrl+Shift+P → Extensions: Show Recommended Extensions
+```
+
+Key extensions: ESLint, Prettier, rust-analyzer, Docker, YAML, Even Better TOML.
+
+The workspace settings in `.vscode/settings.json` configure:
+- Format-on-save with Prettier
+- ESLint auto-fix on save
+- Workspace TypeScript SDK
+- rust-analyzer with all Cargo features enabled
+- Search/file exclusions for `node_modules`, `dist`, `target`
+
+---
+
+## Git Hooks
+
+[husky](https://typicode.github.io/husky/) runs [lint-staged](https://github.com/lint-staged/lint-staged) on every `git commit`. Only staged TypeScript files in `api/src` and `sdk/src` are linted and auto-fixed — unstaged files are never touched.
+
+Hooks are installed automatically by `npm install` via the `prepare` script. If they're not running:
+
+```bash
+npx husky
+```
+
+To bypass in an emergency (avoid habitually):
+
+```bash
+git commit --no-verify -m "your message"
+```
+
+---
+
+## Debugging
+
+The dev override exposes Node.js inspector on port `9229`. In VS Code, add a launch config:
+
+```jsonc
+// .vscode/launch.json
+{
+  "configurations": [
+    {
+      "name": "Attach to Docker API",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "remoteRoot": "/app"
+    }
+  ]
+}
+```
+
+Then start with `--inspect`:
+
+```bash
+# docker-compose.override.yml already adds -w api, so just:
+docker compose up api
+```
+
+---
+
+## Troubleshooting
+
+### `docker compose up` fails to start soroban-quickstart
+
+The quickstart image can take 30–60 seconds on first pull. Wait for the health check to pass:
+
+```bash
+docker compose ps  # wait until soroban-quickstart is "healthy"
+```
+
+If it stays unhealthy:
+
+```bash
+docker compose logs soroban-quickstart
+# Common fix: pull a fresh image
+docker pull stellar/quickstart:latest && docker compose up -d soroban-quickstart
+```
+
+### Postgres "role bridge does not exist"
+
+The volume was created with a different user. Wipe and recreate:
+
+```bash
+docker compose down -v
+docker compose up -d postgres
+npm run migrate -w api
+```
+
+### `ECONNREFUSED` when starting API locally (without Docker)
+
+The API can't reach Postgres or Redis. Either:
+- Start the Docker services: `docker compose up -d postgres redis`
+- Or verify `DATABASE_URL` and `REDIS_URL` in `.env` point to running instances
+
+### Port already in use
+
+```bash
+# Find the process using port 3001
+lsof -i :3001   # macOS/Linux
+# Change PORT in .env to an available port
+```
+
+### `BRIDGE_CONTRACT_ID` not set — funded transactions fail
+
+The API will start but `/api/v1/fund` calls will fail. Deploy the contract locally (see [Manual Setup](#manual-setup) step 6) and set the ID in `.env`.
+
+### ESLint not running on save in VS Code
+
+1. Check `dbaeumer.vscode-eslint` is installed and enabled
+2. Run `npm install` to ensure `eslint` and `@typescript-eslint/parser` are present
+3. Check the ESLint output panel (`View → Output → ESLint`) for errors
+
+### Husky hooks not firing
+
+```bash
+# Reinstall hooks
+npx husky
+
+# Verify the hook file is executable
+ls -la .husky/pre-commit
+chmod +x .husky/pre-commit
+```
+
+### `cargo build` fails — wasm target missing
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+---
+
+## Useful Commands Reference
+
+```bash
+# Start everything
+docker compose up
+
+# Restart just the API (picks up code changes outside hot-reload)
+docker compose restart api
+
+# Open a psql shell
+docker compose exec postgres psql -U bridge bridge
+
+# Redis CLI
+docker compose exec redis redis-cli
+
+# Fund a local G-address via friendbot
+curl "http://localhost:8000/friendbot?addr=<your-G-address>"
+
+# Watch API logs
+docker compose logs -f api
+
+# Run linter across all workspaces
+npm run lint
+
+# Full clean (removes dist, keeps node_modules)
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -10,9 +10,18 @@
   "scripts": {
     "build": "npm run build --workspaces",
     "test": "npm run test --workspaces",
-    "lint": "npm run lint --workspaces"
+    "lint": "npm run lint --workspaces",
+    "prepare": "husky"
   },
   "dependencies": {
     "ioredis": "^5.11.1"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7",
+    "lint-staged": "^15.2.10"
+  },
+  "lint-staged": {
+    "api/src/**/*.ts": "eslint --fix",
+    "sdk/src/**/*.ts": "eslint --fix"
   }
 }

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOLD="\033[1m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+RED="\033[31m"
+RESET="\033[0m"
+
+info()  { echo -e "${BOLD}${GREEN}[setup]${RESET} $*"; }
+warn()  { echo -e "${BOLD}${YELLOW}[warn] ${RESET} $*"; }
+fatal() { echo -e "${BOLD}${RED}[error]${RESET} $*" >&2; exit 1; }
+
+check_cmd() { command -v "$1" &>/dev/null || fatal "$1 is required but not found. $2"; }
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+info "Checking prerequisites..."
+check_cmd node  "Install from https://nodejs.org (v20+)"
+check_cmd npm   "Comes with Node.js"
+check_cmd docker "Install from https://docs.docker.com/get-docker/"
+check_cmd docker "Need Docker with Compose v2"
+
+NODE_VERSION=$(node -e "process.stdout.write(process.version.replace('v',''))")
+MAJOR="${NODE_VERSION%%.*}"
+[[ "$MAJOR" -ge 20 ]] || fatal "Node.js 20+ required, found v${NODE_VERSION}"
+
+# Optional: Rust for contract development
+if command -v cargo &>/dev/null; then
+  info "Rust detected — contract development available"
+else
+  warn "Rust not found. Install via https://rustup.rs if you need to build Soroban contracts."
+fi
+
+# ── Environment file ──────────────────────────────────────────────────────────
+if [[ ! -f .env ]]; then
+  info "Creating .env from .env.local.example..."
+  cp .env.local.example .env
+  warn "Review .env and fill in BRIDGE_CONTRACT_ID before running the API."
+else
+  info ".env already exists — skipping copy"
+fi
+
+# ── Node dependencies ─────────────────────────────────────────────────────────
+info "Installing Node.js dependencies..."
+npm install
+
+# ── Git hooks ─────────────────────────────────────────────────────────────────
+info "Installing git hooks (husky)..."
+npx husky || warn "Husky setup failed — git hooks won't run. Re-run 'npx husky' manually."
+
+# ── Docker stack ──────────────────────────────────────────────────────────────
+info "Starting Docker Compose stack (postgres, redis, soroban-quickstart)..."
+docker compose up -d postgres redis soroban-quickstart
+
+info "Waiting for Postgres to be healthy..."
+for i in $(seq 1 30); do
+  docker compose exec -T postgres pg_isready -U bridge &>/dev/null && break
+  sleep 2
+  [[ "$i" -eq 30 ]] && fatal "Postgres never became healthy"
+done
+
+# ── Database migrations ───────────────────────────────────────────────────────
+info "Running database migrations..."
+DATABASE_URL="${DATABASE_URL:-postgres://bridge:bridge@localhost:5432/bridge}"
+export DATABASE_URL
+npm run migrate -w api || warn "Migrations failed — check DATABASE_URL in .env"
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+info "Building TypeScript packages..."
+npm run build
+
+echo ""
+echo -e "${BOLD}${GREEN}✓ Dev environment ready!${RESET}"
+echo ""
+echo "  Start the full stack:    docker compose up"
+echo "  Start API only (hot):    npm run dev -w api"
+echo "  Run tests:               npm test"
+echo "  Soroban RPC:             http://localhost:8000/soroban/rpc"
+echo "  Friendbot (fund accts):  http://localhost:8000/friendbot?addr=<G-address>"
+echo "  API:                     http://localhost:${PORT:-3001}"
+echo "  API health:              http://localhost:${PORT:-3001}/health"
+echo ""


### PR DESCRIPTION
Closes #90 

- docker-compose.yml: full stack (API, Postgres 16, Redis 7, Soroban quickstart)
- docker-compose.override.yml: dev overrides with tsx hot reload and Node inspector (port 9229)
- .env.local.example: local dev defaults wired to Docker services
- scripts/setup-dev.sh: one-shot bootstrap (deps, .env, Docker, migrations, build)
- docs/developer-setup.md: step-by-step guide, env vars, migrations, tests, debugging, troubleshooting
- .vscode/settings.json + extensions.json: format-on-save, ESLint, rust-analyzer, recommended extensions
- .husky/pre-commit + lint-staged: pre-commit linting for staged TS files
- package.json: add husky + lint-staged devDependencies and prepare script
- .gitignore: track .vscode/settings.json and extensions.json, ignore personal overrides