### PR TITLE
feat: connection pooling for Soroban RPC and database (#110)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Soroban RPC endpoints
+# Comma-separate multiple endpoints to enable per-endpoint failover pooling
 SOROBAN_RPC_URL=https://soroban-rpc.testnet.stellar.org
 SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Outbound HTTP keep-alive connection pool (Soroban RPC) — issue #110
+HTTP_AGENT_MAX_SOCKETS=50
+HTTP_AGENT_MAX_FREE_SOCKETS=10
+HTTP_AGENT_KEEP_ALIVE_MS=15000
 
 # Contract address (testnet deployment)
 BRIDGE_CONTRACT_ID=CD3YJ3M7PQ5PF7XT4NL2AX7XINJWXZ7TAIHY36NI6NWW2UABAAOAFAIC
@@ -43,6 +49,16 @@ REDIS_QUOTE_TTL_SECONDS=30
 REDIS_STATUS_TTL_SECONDS=10
 REDIS_CEX_TTL_SECONDS=60
 REDIS_TRANSACTIONS_TTL_SECONDS=5
+
+# PostgreSQL connection pool (issue #110)
+# DATABASE_URL is optional; pooling activates only when it is set
+DATABASE_URL=
+DB_POOL_MIN=2
+DB_POOL_MAX=20
+DB_IDLE_TIMEOUT_MS=10000
+DB_CONNECTION_TIMEOUT_MS=5000
+DB_STATEMENT_TIMEOUT_MS=30000
+DB_SSL=false
 
 # Idempotency (issue #31)
 # Set to true to require X-Idempotency-Key on POST /api/v1/fund

--- a/api/src/__tests__/db.test.ts
+++ b/api/src/__tests__/db.test.ts
@@ -10,7 +10,7 @@ vi.mock('../config', () => ({
   },
 }));
 
-import { getPool, dbHealthCheck } from '../services/db';
+import { getPool, dbHealthCheck, getPoolMetrics } from '../services/db';
 
 describe('db service (no DATABASE_URL)', () => {
   it('getPool returns null when DATABASE_URL is not set', () => {
@@ -21,5 +21,9 @@ describe('db service (no DATABASE_URL)', () => {
   it('dbHealthCheck returns ok (skip) when database not configured', async () => {
     const result = await dbHealthCheck();
     expect(result.ok).toBe(true);
+  });
+
+  it('getPoolMetrics returns null when database not configured', () => {
+    expect(getPoolMetrics()).toBeNull();
   });
 });

--- a/api/src/__tests__/httpAgent.test.ts
+++ b/api/src/__tests__/httpAgent.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+process.env.NODE_ENV = 'test';
+
+vi.mock('../index', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../config', () => ({
+  config: {
+    httpAgent: { maxSockets: 25, maxFreeSockets: 5, keepAliveMsecs: 1000 },
+  },
+}));
+
+import { SorobanRpc } from '@stellar/stellar-sdk';
+import { applyKeepAliveAgents, getAgentStats, destroyAgents } from '../services/httpAgent';
+
+describe('httpAgent (Soroban RPC connection pooling)', () => {
+  it('installs keep-alive agents on the Stellar SDK axios client', () => {
+    applyKeepAliveAgents();
+    const client = SorobanRpc.AxiosClient as { defaults: { httpsAgent?: { keepAlive?: boolean; maxSockets?: number } } };
+    expect(client.defaults.httpsAgent?.keepAlive).toBe(true);
+    expect(client.defaults.httpsAgent?.maxSockets).toBe(25);
+  });
+
+  it('is idempotent', () => {
+    expect(() => {
+      applyKeepAliveAgents();
+      applyKeepAliveAgents();
+    }).not.toThrow();
+  });
+
+  it('reports socket reuse stats', () => {
+    const stats = getAgentStats();
+    expect(stats).toHaveProperty('activeSockets');
+    expect(stats).toHaveProperty('freeSockets');
+    expect(stats).toHaveProperty('pendingRequests');
+    expect(stats.activeSockets).toBeGreaterThanOrEqual(0);
+  });
+
+  it('destroyAgents drains without throwing', () => {
+    expect(() => destroyAgents()).not.toThrow();
+  });
+});

--- a/api/src/config.ts
+++ b/api/src/config.ts
@@ -90,10 +90,18 @@ export const config = {
   },
   database: {
     url: process.env.DATABASE_URL || '',
-    poolMax: parseInt(process.env.DB_POOL_MAX || '10', 10),
-    idleTimeoutMs: parseInt(process.env.DB_IDLE_TIMEOUT_MS || '30000', 10),
+    poolMin: parseInt(process.env.DB_POOL_MIN || '2', 10),
+    poolMax: parseInt(process.env.DB_POOL_MAX || '20', 10),
+    idleTimeoutMs: parseInt(process.env.DB_IDLE_TIMEOUT_MS || '10000', 10),
     connectionTimeoutMs: parseInt(process.env.DB_CONNECTION_TIMEOUT_MS || '5000', 10),
+    statementTimeoutMs: parseInt(process.env.DB_STATEMENT_TIMEOUT_MS || '30000', 10),
     ssl: process.env.DB_SSL === 'true',
+  },
+  /** Keep-alive connection pooling for outbound HTTP (Soroban RPC). */
+  httpAgent: {
+    maxSockets: parseInt(process.env.HTTP_AGENT_MAX_SOCKETS || '50', 10),
+    maxFreeSockets: parseInt(process.env.HTTP_AGENT_MAX_FREE_SOCKETS || '10', 10),
+    keepAliveMsecs: parseInt(process.env.HTTP_AGENT_KEEP_ALIVE_MS || '15000', 10),
   },
   websocket: {
     authRequired: process.env.WS_AUTH_REQUIRED !== 'false',

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,6 +32,7 @@ import { securityMiddleware, contentTypeEnforcement } from './middleware/securit
 import { requestTracker } from './middleware/requestTracker';
 import { loggingMiddleware } from './middleware/logging';
 import { gracefulShutdown, registerSignalHandlers } from './shutdown';
+import { closePool } from './services/db';
 import { isRedisEnabled, getCacheMetrics } from './services/cache';
 import { getHealthStatus } from './services/health';
 import { updateCircuitBreakerMetrics, activeRequestsGauge, httpRequestCounter, httpRequestDuration } from './services/metrics';
@@ -199,6 +200,20 @@ if (process.env.NODE_ENV !== 'test') {
 
   gracefulShutdown.attach(server, logger);
 
+  // Drain all external-service connection pools on shutdown.
+  // Imported lazily so the RPC pool / keep-alive agents aren't constructed
+  // during this module's early initialization.
+  const drainConnectionPools = async () => {
+    const [{ rpcPool }, { destroyAgents }] = await Promise.all([
+      import('./services/rpcPool'),
+      import('./services/httpAgent'),
+    ]);
+    rpcPool.destroy();
+    destroyAgents();
+    await closePool();
+    logger.info('connection pools drained');
+  };
+
   if (config.jobs.enabled) {
     import('./jobs/queue').then(async ({ getAllQueues, scheduleRecurringJobs, closeQueues }) => {
       const { createBullBoard } = await import('@bull-board/api');
@@ -215,17 +230,20 @@ if (process.env.NODE_ENV !== 'test') {
 
       registerSignalHandlers(async () => {
         await closeQueues();
+        await drainConnectionPools();
         await shutdownTracing();
         logger.info('job queues closed');
       });
     }).catch((err: Error) => {
       logger.error({ err }, 'failed to initialize job queues');
       registerSignalHandlers(async () => {
+        await drainConnectionPools();
         await shutdownTracing();
       });
     });
   } else {
     registerSignalHandlers(async () => {
+      await drainConnectionPools();
       await shutdownTracing();
     });
   }

--- a/api/src/services/db.ts
+++ b/api/src/services/db.ts
@@ -1,6 +1,8 @@
 import { Pool, PoolClient } from 'pg';
+import { Gauge } from 'prom-client';
 import { config } from '../config';
 import { logger } from '../logger';
+import { register } from './metrics';
 
 let pool: Pool | null = null;
 
@@ -10,9 +12,11 @@ export function getPool(): Pool | null {
 
   pool = new Pool({
     connectionString: config.database.url,
+    min: config.database.poolMin,
     max: config.database.poolMax,
     idleTimeoutMillis: config.database.idleTimeoutMs,
     connectionTimeoutMillis: config.database.connectionTimeoutMs,
+    statement_timeout: config.database.statementTimeoutMs,
     ssl: config.database.ssl ? { rejectUnauthorized: false } : false,
   });
 
@@ -22,6 +26,61 @@ export function getPool(): Pool | null {
 
   return pool;
 }
+
+export interface PoolMetrics {
+  /** Total connections in the pool (idle + active). */
+  total: number;
+  /** Idle connections available for checkout. */
+  idle: number;
+  /** Connections currently checked out and in use. */
+  active: number;
+  /** Queued requests waiting for a free connection. */
+  waiting: number;
+}
+
+/** Live snapshot of the PostgreSQL pool, or null when the DB is not configured. */
+export function getPoolMetrics(): PoolMetrics | null {
+  if (!pool) return null;
+  const total = pool.totalCount;
+  const idle = pool.idleCount;
+  return { total, idle, active: total - idle, waiting: pool.waitingCount };
+}
+
+// ─── Pool metrics ──────────────────────────────────────────────────────────────
+// Sampled on every scrape via collect() so values are always current without a
+// background timer. No-op while the database is unconfigured.
+
+const dbPoolActive = new Gauge({
+  name: 'db_pool_connections_active',
+  help: 'Active (checked-out) PostgreSQL pool connections',
+  registers: [register],
+});
+
+const dbPoolIdle = new Gauge({
+  name: 'db_pool_connections_idle',
+  help: 'Idle PostgreSQL pool connections',
+  registers: [register],
+});
+
+const dbPoolWaiting = new Gauge({
+  name: 'db_pool_waiting_requests',
+  help: 'Requests waiting for a free PostgreSQL connection',
+  registers: [register],
+});
+
+new Gauge({
+  name: 'db_pool_connections_total',
+  help: 'Total PostgreSQL pool connections (idle + active)',
+  registers: [register],
+  collect() {
+    const m = getPoolMetrics();
+    if (!m) return;
+    this.set(m.total);
+    dbPoolActive.set(m.active);
+    dbPoolIdle.set(m.idle);
+    dbPoolWaiting.set(m.waiting);
+  },
+});
 
 export async function dbHealthCheck(): Promise<{ ok: boolean; latencyMs?: number; error?: string }> {
   const p = getPool();

--- a/api/src/services/httpAgent.ts
+++ b/api/src/services/httpAgent.ts
@@ -1,0 +1,136 @@
+import http from 'http';
+import https from 'https';
+import { Gauge } from 'prom-client';
+import { SorobanRpc } from '@stellar/stellar-sdk';
+import { config } from '../config';
+import { logger } from '../index';
+import { register } from './metrics';
+
+/**
+ * HTTP keep-alive connection pooling for outbound Soroban RPC traffic.
+ *
+ * The Stellar SDK performs every RPC call through a single shared axios
+ * instance (`SorobanRpc.AxiosClient`). By default that instance opens a fresh
+ * TCP (and TLS) connection per request, which adds handshake latency and churns
+ * sockets. Installing keep-alive agents lets axios reuse a pool of sockets per
+ * origin, so repeated calls to the same RPC endpoint ride existing connections.
+ */
+
+interface AgentOptions {
+  maxSockets: number;
+  maxFreeSockets: number;
+  keepAliveMsecs: number;
+}
+
+function buildAgents(opts: AgentOptions): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+  const shared = {
+    keepAlive: true,
+    maxSockets: opts.maxSockets,
+    maxFreeSockets: opts.maxFreeSockets,
+    keepAliveMsecs: opts.keepAliveMsecs,
+    scheduling: 'lifo' as const,
+  };
+  return {
+    httpAgent: new http.Agent(shared),
+    httpsAgent: new https.Agent(shared),
+  };
+}
+
+// Fall back to sane defaults so the module is robust even when invoked with a
+// partial config (e.g. mocked in unit tests).
+const agentConfig: AgentOptions = config.httpAgent ?? {
+  maxSockets: 50,
+  maxFreeSockets: 10,
+  keepAliveMsecs: 15000,
+};
+
+const { httpAgent, httpsAgent } = buildAgents(agentConfig);
+
+let applied = false;
+
+/**
+ * Installs the keep-alive agents on the Stellar SDK's shared axios client.
+ * Idempotent — safe to call from every module that touches the RPC pool.
+ */
+export function applyKeepAliveAgents(): void {
+  if (applied) return;
+  const client = SorobanRpc.AxiosClient as { defaults: { httpAgent?: http.Agent; httpsAgent?: https.Agent } };
+  client.defaults.httpAgent = httpAgent;
+  client.defaults.httpsAgent = httpsAgent;
+  applied = true;
+  // `logger` may be undefined if this runs during the index module's cyclic
+  // initialization; the log line is non-essential, so guard it.
+  logger?.info?.(
+    { maxSockets: agentConfig.maxSockets, maxFreeSockets: agentConfig.maxFreeSockets },
+    'soroban rpc keep-alive agents installed',
+  );
+}
+
+export interface AgentStats {
+  /** Sockets currently in use (one per in-flight request). */
+  activeSockets: number;
+  /** Idle keep-alive sockets available for reuse. */
+  freeSockets: number;
+  /** Requests queued because all sockets are busy. */
+  pendingRequests: number;
+}
+
+function countSockets(record: Record<string, unknown[]> | undefined): number {
+  if (!record) return 0;
+  return Object.values(record).reduce((sum, arr) => sum + (Array.isArray(arr) ? arr.length : 0), 0);
+}
+
+/**
+ * Snapshot of socket reuse across both agents — surfaced via metrics so the
+ * connection pool's effectiveness (free sockets ⇒ reuse) is observable.
+ */
+export function getAgentStats(): AgentStats {
+  const agents = [httpAgent, httpsAgent] as Array<{
+    sockets?: Record<string, unknown[]>;
+    freeSockets?: Record<string, unknown[]>;
+    requests?: Record<string, unknown[]>;
+  }>;
+  let activeSockets = 0;
+  let freeSockets = 0;
+  let pendingRequests = 0;
+  for (const a of agents) {
+    activeSockets += countSockets(a.sockets);
+    freeSockets += countSockets(a.freeSockets);
+    pendingRequests += countSockets(a.requests);
+  }
+  return { activeSockets, freeSockets, pendingRequests };
+}
+
+/** Drains all idle keep-alive sockets. Called during graceful shutdown. */
+export function destroyAgents(): void {
+  httpAgent.destroy();
+  httpsAgent.destroy();
+}
+
+// ─── Socket-reuse metrics ────────────────────────────────────────────────────
+// Sampled on every scrape so the pool's connection-reuse effectiveness is
+// observable (a high free-socket count means connections are being reused).
+
+const rpcSocketsFree = new Gauge({
+  name: 'rpc_keepalive_sockets_free',
+  help: 'Free (reusable) Soroban RPC keep-alive sockets',
+  registers: [register],
+});
+
+const rpcSocketsPending = new Gauge({
+  name: 'rpc_keepalive_pending_requests',
+  help: 'Soroban RPC requests waiting for an available socket',
+  registers: [register],
+});
+
+new Gauge({
+  name: 'rpc_keepalive_sockets_active',
+  help: 'Active Soroban RPC keep-alive sockets',
+  registers: [register],
+  collect() {
+    const s = getAgentStats();
+    this.set(s.activeSockets);
+    rpcSocketsFree.set(s.freeSockets);
+    rpcSocketsPending.set(s.pendingRequests);
+  },
+});

--- a/api/src/services/rpcPool.ts
+++ b/api/src/services/rpcPool.ts
@@ -1,6 +1,7 @@
 import { SorobanRpc } from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { logger } from '../index';
+import { applyKeepAliveAgents } from './httpAgent';
 
 interface ProviderState {
   url: string;
@@ -22,6 +23,9 @@ export class RpcPool {
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor() {
+    // Reuse TCP/TLS connections per RPC endpoint via shared keep-alive agents.
+    applyKeepAliveAgents();
+
     const { rpcUrls, rpc } = config.soroban;
     this.strategy = rpc.selectionStrategy;
     this.failureThreshold = rpc.failureThreshold;


### PR DESCRIPTION
## Summary

Implements connection pooling for outbound external-service connections, addressing #110.

### Soroban RPC — HTTP keep-alive agent pooling
- New `api/src/services/httpAgent.ts` installs shared `http.Agent`/`https.Agent` (`keepAlive: true`) on the Stellar SDK's axios client (`SorobanRpc.AxiosClient`), so RPC calls reuse TCP/TLS connections per endpoint instead of opening a fresh connection per request.
- Configurable `maxSockets`, `maxFreeSockets`, `keepAliveMsecs` (env-driven).
- Applied once on RPC pool construction; idempotent.

### PostgreSQL pool
- Defaults aligned with the issue: **min 2, max 20, idle 10s, connection 5s, statement timeout 30s** — all configurable.
- `getPoolMetrics()` exposes total / active / idle / waiting.

### Metrics (visible at `/metrics`)
- `db_pool_connections_total`, `db_pool_connections_active`, `db_pool_connections_idle`, `db_pool_waiting_requests`
- `rpc_keepalive_sockets_active`, `rpc_keepalive_sockets_free`, `rpc_keepalive_pending_requests` (connection-reuse monitoring)
- Sampled on each scrape via prom-client `collect()` callbacks — no background timers.

### Graceful drain on shutdown
- SIGTERM/SIGINT now drain the RPC pool, keep-alive agents, and PostgreSQL pool across all signal-handler paths.

### Redis
- Native pooling already handled by `ioredis` (no change needed).

## Acceptance criteria
- [x] Connection pooling active for all external services (RPC keep-alive, PG pool, Redis native)
- [x] Pool metrics visible in monitoring
- [x] Graceful drain on shutdown
- [x] Connection health checks (RPC health checks + `dbHealthCheck` retained)

## Testing
- `tsc --noEmit` passes.
- New `httpAgent.test.ts` (agent install / reuse stats / drain) and `db.test.ts` pool-metrics assertion.
- Full suite passes except one pre-existing, environment-dependent `logging.test.ts` health assertion (fails on a clean tree too — no network in sandbox).

Closes #110