### PR TITLE
fix: align Docker exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ COPY api/dist/ api/dist/
 COPY api/node_modules/ api/node_modules/
 COPY sdk/ sdk/
 RUN npm ci --production --workspace=api
-EXPOSE 3000
+EXPOSE 3001
 CMD ["node", "api/dist/index.js"]


### PR DESCRIPTION
## Summary\n- Update the Dockerfile exposed port to 3001 so it matches the backend default port.\n- Keep container metadata aligned with README/API config expectations.\n\n## Validation\n- Verified Dockerfile, README, and api/src/config.ts all reference the 3001 backend default where relevant.\n- Ran git diff --check.