### PR TITLE
fix: versioning dedupe, CIDR /0 + IPv6 support, transactions:read scope

### DIFF
--- a/api/src/middleware/rbacAuth.ts
+++ b/api/src/middleware/rbacAuth.ts
@@ -8,6 +8,7 @@ export type PermissionScope =
   | 'status:read'
   | 'offramp:write'
   | 'cex:read'
+  | 'transactions:read'
   | 'admin:keys';
 
 export interface ApiKeyRecord {
@@ -43,8 +44,18 @@ function hashKey(rawKey: string): string {
 
 function matchesCidr(ip: string, cidr: string): boolean {
   if (!cidr.includes('/')) return ip === cidr;
-  const [network, bits] = cidr.split('/');
-  const mask = ~((1 << (32 - parseInt(bits, 10))) - 1) >>> 0;
+  const [network, bitsStr] = cidr.split('/');
+  const bits = parseInt(bitsStr, 10);
+
+  if (ip.includes(':') || network.includes(':')) {
+    const ipNum = ipv6ToBigInt(ip);
+    const netNum = ipv6ToBigInt(network);
+    if (ipNum === null || netNum === null) return false;
+    const mask = ((1n << BigInt(bits)) - 1n) << BigInt(128 - bits);
+    return (ipNum & mask) === (netNum & mask);
+  }
+
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
   const ipNum = ipToNum(ip);
   const netNum = ipToNum(network);
   if (ipNum === null || netNum === null) return false;
@@ -55,6 +66,39 @@ function ipToNum(ip: string): number | null {
   const parts = ip.split('.');
   if (parts.length !== 4) return null;
   return parts.reduce((acc, p) => (acc << 8) + parseInt(p, 10), 0) >>> 0;
+}
+
+function ipv6ToBigInt(ip: string): bigint | null {
+  if (!ip.includes(':')) return null;
+
+  let groups: string[];
+  if (ip.includes('::')) {
+    const [left, right] = ip.split('::');
+    if (left.includes('::') || right.includes('::')) return null;
+    const leftParts = left ? left.split(':') : [];
+    const rightParts = right ? right.split(':') : [];
+    const missing = 8 - (leftParts.length + rightParts.length);
+    if (missing < 0) return null;
+    groups = [...leftParts, ...Array(missing).fill('0'), ...rightParts];
+  } else {
+    groups = ip.split(':');
+  }
+
+  if (groups.length > 0 && groups[groups.length - 1].includes('.')) {
+    const v4Num = ipToNum(groups.pop() as string);
+    if (v4Num === null) return null;
+    groups.push(((v4Num >>> 16) & 0xffff).toString(16));
+    groups.push((v4Num & 0xffff).toString(16));
+  }
+
+  if (groups.length !== 8) return null;
+
+  let result = 0n;
+  for (const g of groups) {
+    if (g === '' || !/^[0-9a-fA-F]{1,4}$/.test(g)) return null;
+    result = (result << 16n) | BigInt(parseInt(g, 16));
+  }
+  return result;
 }
 
 function isIpAllowed(ip: string, whitelist: string[]): boolean {

--- a/api/src/middleware/versioning.ts
+++ b/api/src/middleware/versioning.ts
@@ -8,7 +8,6 @@ function normalizeVersion(value: string | undefined): ApiVersion | undefined {
   if (version === 'v2') return 'v2';
   if (version === 'v1' || version === '1') return 'v1';
   if (version === '2') return 'v2';
-  if (version === '1' || version === 'v1') return 'v1';
   return undefined;
 }
 

--- a/api/src/routes/transactions.ts
+++ b/api/src/routes/transactions.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { rbacAuth } from '../middleware/rbacAuth';
+import { rbacAuth, requireScopes } from '../middleware/rbacAuth';
 import {
   listTransactions,
   serializeTransactionsCsv,
@@ -12,7 +12,7 @@ export const transactionsRouter = Router();
 
 export const TRANSACTIONS_CACHE_NAMESPACE = 'transactions';
 
-transactionsRouter.get('/', rbacAuth, async (req: Request, res: Response) => {
+transactionsRouter.get('/', rbacAuth, requireScopes('transactions:read'), async (req: Request, res: Response) => {
   const status = typeof req.query.status === 'string' ? (req.query.status as TransactionStatus) : undefined;
   const fromDate = typeof req.query.fromDate === 'string' ? req.query.fromDate : undefined;
   const toDate = typeof req.query.toDate === 'string' ? req.query.toDate : undefined;


### PR DESCRIPTION
## Summary

Fixes four issues in the middleware/routing layer:

- **#211** — `versioning.ts` had a duplicated/dead branch in `normalizeVersion` (`'1' || 'v1'` checked twice); removed the redundant condition.
- **#210** — `matchesCidr`'s mask computation broke for `/0` CIDR entries due to JS's shift-amount-mod-32 behavior (`1 << 32` wrapped to `1 << 0`); special-cased `bits === 0` to produce a zero mask that matches any address.
- **#209** — `matchesCidr`/`ipToNum` had no IPv6 support, so IPv6 client IPs were silently rejected whenever an `ipWhitelist` was configured; added `ipv6ToBigInt` parsing (including `::` compression and embedded IPv4-mapped addresses) and BigInt-based CIDR matching for IPv6 addresses/whitelist entries.
- **#208** — `transactionsRouter` had no dedicated scope requirement, exposing system-wide transaction records and CSV export to any valid API key; added a `transactions:read` scope to `PermissionScope` and required it via `requireScopes('transactions:read')` on the router.

Per instructions, test additions listed in each issue's checklist were skipped for this PR.

Closes #211
Closes #210
Closes #209
Closes #208

## Test plan

- [x] `npm run build --workspace api` passes
- [ ] Tests intentionally skipped per task instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)