### PR TITLE
fix: mask webhook log headers, fix redaction filter, C-address validation, rate-limit tier spoofing

### DIFF
--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -158,9 +158,7 @@ const sensitivePaths = [
   'secretKey',
   ...config.logging.sensitiveFields
     .map((f) => f.trim())
-    .filter(Boolean)
-    .filter((f) => !f.includes('-'))
-    .map((f) => (f.includes('.') ? f : f)),
+    .filter(Boolean),
 ];
 
 const stream = new AggregationStream(

--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -47,11 +47,11 @@ function banIP(ip: string, pattern: string): void {
 }
 
 function resolveTier(req: Request): 'low' | 'standard' | 'high' {
-  const tier = req.apiKeyRecord?.rateLimit ?? req.headers['x-rate-limit-tier'];
+  const tier = req.apiKeyRecord?.rateLimit;
   if (tier === 'low' || tier === 'standard' || tier === 'high') {
     return tier;
   }
-  return 'standard';
+  return 'low';
 }
 
 function createLimiter(max: number, keyPrefix: string) {

--- a/api/src/middleware/webhookVerification.ts
+++ b/api/src/middleware/webhookVerification.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../index';
+import { maskHeaders } from './logging';
 
 export interface WebhookVerifier {
   headerName: string;
@@ -80,7 +81,10 @@ function buildWebhookVerifier(provider: string) {
     const ip = req.ip ?? 'unknown';
 
     if (!signature) {
-      logger.warn({ ip, provider, path: req.path, headers: req.headers }, 'webhook missing signature header');
+      logger.warn(
+        { ip, provider, path: req.path, headers: maskHeaders(req.headers as Record<string, string | string[] | undefined>) },
+        'webhook missing signature header',
+      );
       res.status(401).json({ error: 'unauthorized', message: 'missing webhook signature' });
       return;
     }

--- a/api/src/routes/cex.ts
+++ b/api/src/routes/cex.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { STELLAR_ADDRESS_REGEX } from '../utils/constants';
+import { C_ADDRESS_REGEX } from '../utils/constants';
 import { cexService } from '../services/cex';
 import { exchangeRoutingCount } from '../services/metrics';
 import { buildCacheKey, CACHE_TTL, getOrCompute } from '../services/cache';
@@ -12,7 +12,7 @@ const routeSchema = z.object({
   exchange: z.enum(['binance', 'coinbase', 'kraken', 'generic']),
   sourceAsset: z.string().min(1),
   amount: z.string().regex(/^\d+$/, 'amount must be an integer string (stroops)'),
-  targetCAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'invalid target C-address'),
+  targetCAddress: z.string().regex(C_ADDRESS_REGEX, 'invalid target C-address'),
   targetNetwork: z.string().default('stellar'),
   memo: z.string().max(64).optional(),
 });

--- a/api/src/routes/funding.ts
+++ b/api/src/routes/funding.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { STELLAR_ADDRESS_REGEX } from '../utils/constants';
+import { STELLAR_ADDRESS_REGEX, C_ADDRESS_REGEX } from '../utils/constants';
 import { sorobanService } from '../services/soroban';
 import { explorerService } from '../services/explorer';
 import { idempotencyMiddleware } from '../middleware/idempotency';
@@ -25,8 +25,8 @@ const fundSchema = z.object({
 
 const fundDirectSchema = z.object({
   sourceAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'invalid source Stellar address'),
-  targetAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'invalid target C-address'),
-  tokenAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'invalid token contract address'),
+  targetAddress: z.string().regex(C_ADDRESS_REGEX, 'invalid target C-address'),
+  tokenAddress: z.string().regex(C_ADDRESS_REGEX, 'invalid token contract address'),
   amount: z.string().regex(/^\d+$/, 'amount must be an integer string (stroops)'),
   memo: z.string().max(64).default(''),
 });


### PR DESCRIPTION
## Summary

Fixes four security/bug good-first-issues:

- **#203** — `webhookVerification.ts` logged the raw `req.headers` object (including `authorization`/`x-api-key`) on missing-signature warnings. Now reuses `maskHeaders()` from `middleware/logging.ts`.
- **#202** — the pino redaction path builder in `logger.ts` filtered out any hyphenated field name (`.filter((f) => !f.includes('-'))`), silently dropping the default `x-api-key` entry from `redact.paths`. Removed the filter/no-op map so hyphenated fields are preserved.
- **#201** — `targetAddress`/`tokenAddress` in `funding.ts` and `targetCAddress` in `cex.ts` are C-address-only fields but validated against `STELLAR_ADDRESS_REGEX` (which also matches `G` addresses). Switched them to `C_ADDRESS_REGEX`. `sourceAddress` in `funding.ts` is left on `STELLAR_ADDRESS_REGEX` since it legitimately accepts either address type.
- **#200** — `resolveTier()` in `rateLimit.ts` fell back to the client-supplied `X-Rate-Limit-Tier` header when no `apiKeyRecord` was present, letting a caller self-select an elevated bucket. Removed the header fallback; unauthenticated/unresolved requests now default to the `low` tier.

Per task instructions, tests were skipped for this batch.

Closes #203
Closes #202
Closes #201
Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)