### PR TITLE
fix: webhook retry URL, PATCH mass-assignment, and DLQ secret leak

### DIFF
--- a/api/src/jobs/processors/webhookRetry.ts
+++ b/api/src/jobs/processors/webhookRetry.ts
@@ -1,5 +1,6 @@
 import { Job } from 'bullmq';
 import { WebhookRetryData } from '../queue';
+import { webhookDeliveryService } from '../../services/webhookDelivery';
 import pino from 'pino';
 
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
@@ -9,11 +10,17 @@ export async function processWebhookRetry(job: Job<WebhookRetryData>): Promise<v
   const { registrationId, payload, event, attemptNumber } = job.data;
   logger.info({ registrationId, event, attemptNumber }, 'retrying webhook delivery');
 
+  const registration = webhookDeliveryService.getRegistration(registrationId);
+  if (!registration) {
+    logger.warn({ registrationId, event }, 'webhook retry skipped: registration no longer exists');
+    return;
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), DELIVERY_TIMEOUT_MS);
 
   try {
-    const response = await fetch(registrationId, {
+    const response = await fetch(registration.url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ event, payload }),

--- a/api/src/routes/apiKeys.ts
+++ b/api/src/routes/apiKeys.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import { z } from 'zod';
 import {
   createApiKey,
   revokeApiKey,
@@ -11,6 +12,19 @@ import {
 } from '../middleware/rbacAuth';
 
 export const apiKeysRouter = Router();
+
+const updateApiKeySchema = z
+  .object({
+    name: z.string().min(1),
+    scopes: z.array(
+      z.enum(['quote:read', 'fund:write', 'status:read', 'offramp:write', 'cex:read', 'admin:keys']),
+    ),
+    ipWhitelist: z.array(z.string()),
+    expiresAt: z.number().nullable(),
+    rateLimit: z.enum(['low', 'standard', 'high']),
+  })
+  .partial()
+  .strict();
 
 apiKeysRouter.post('/', requireScopes('admin:keys'), (req: Request, res: Response) => {
   const { name, scopes, ipWhitelist, expiresAt, rateLimit } = req.body as {
@@ -50,7 +64,13 @@ apiKeysRouter.get('/:id', requireScopes('admin:keys'), (req: Request, res: Respo
 });
 
 apiKeysRouter.patch('/:id', requireScopes('admin:keys'), (req: Request, res: Response) => {
-  const updated = updateApiKey(req.params.id, req.body as Parameters<typeof updateApiKey>[1]);
+  const parsed = updateApiKeySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'bad_request', message: 'invalid patch body', issues: parsed.error.issues });
+    return;
+  }
+
+  const updated = updateApiKey(req.params.id, parsed.data);
   if (!updated) {
     res.status(404).json({ error: 'not_found' });
     return;

--- a/api/src/routes/webhookAdmin.ts
+++ b/api/src/routes/webhookAdmin.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 import { webhookDeliveryService } from '../services/webhookDelivery';
+import { requireScopes } from '../middleware/rbacAuth';
 
 export const webhookAdminRouter = Router();
 
@@ -11,7 +12,7 @@ const registerSchema = z.object({
 });
 
 // Register a webhook callback URL
-webhookAdminRouter.post('/register', (req: Request, res: Response, next: NextFunction) => {
+webhookAdminRouter.post('/register', requireScopes('admin:keys'), (req: Request, res: Response, next: NextFunction) => {
   try {
     const apiKey = req.headers['x-api-key'] as string;
     const body = registerSchema.parse(req.body);
@@ -28,7 +29,7 @@ webhookAdminRouter.post('/register', (req: Request, res: Response, next: NextFun
 });
 
 // List registered webhooks for the current API key
-webhookAdminRouter.get('/registrations', (req: Request, res: Response) => {
+webhookAdminRouter.get('/registrations', requireScopes('admin:keys'), (req: Request, res: Response) => {
   const apiKey = req.headers['x-api-key'] as string;
   const registrations = webhookDeliveryService.getRegistrationsByApiKey(apiKey).map((r) => ({
     id: r.id,
@@ -40,7 +41,7 @@ webhookAdminRouter.get('/registrations', (req: Request, res: Response) => {
 });
 
 // Delete a registration
-webhookAdminRouter.delete('/registrations/:id', (req: Request, res: Response) => {
+webhookAdminRouter.delete('/registrations/:id', requireScopes('admin:keys'), (req: Request, res: Response) => {
   const deleted = webhookDeliveryService.unregister(req.params.id);
   if (!deleted) {
     res.status(404).json({ error: 'not_found', message: 'registration not found' });
@@ -50,7 +51,7 @@ webhookAdminRouter.delete('/registrations/:id', (req: Request, res: Response) =>
 });
 
 // DLQ inspection — list all failed deliveries
-webhookAdminRouter.get('/dlq', (_req: Request, res: Response) => {
+webhookAdminRouter.get('/dlq', requireScopes('admin:keys'), (_req: Request, res: Response) => {
   const entries = webhookDeliveryService.getDLQ().map((e) => ({
     id: e.id,
     registrationId: e.registration.id,
@@ -63,17 +64,18 @@ webhookAdminRouter.get('/dlq', (_req: Request, res: Response) => {
 });
 
 // DLQ entry detail — full payload and attempt history
-webhookAdminRouter.get('/dlq/:id', (req: Request, res: Response) => {
+webhookAdminRouter.get('/dlq/:id', requireScopes('admin:keys'), (req: Request, res: Response) => {
   const entry = webhookDeliveryService.getDLQEntry(req.params.id);
   if (!entry) {
     res.status(404).json({ error: 'not_found', message: 'DLQ entry not found' });
     return;
   }
-  res.json(entry);
+  const { secret: _secret, apiKey: _apiKey, ...safeRegistration } = entry.registration;
+  res.json({ ...entry, registration: safeRegistration });
 });
 
 // Remove a DLQ entry after manual inspection / resolution
-webhookAdminRouter.delete('/dlq/:id', (req: Request, res: Response) => {
+webhookAdminRouter.delete('/dlq/:id', requireScopes('admin:keys'), (req: Request, res: Response) => {
   const deleted = webhookDeliveryService.deleteDLQEntry(req.params.id);
   if (!deleted) {
     res.status(404).json({ error: 'not_found', message: 'DLQ entry not found' });
@@ -83,11 +85,11 @@ webhookAdminRouter.delete('/dlq/:id', (req: Request, res: Response) => {
 });
 
 // Webhook health dashboard
-webhookAdminRouter.get('/stats', (_req: Request, res: Response) => {
+webhookAdminRouter.get('/stats', requireScopes('admin:keys'), (_req: Request, res: Response) => {
   res.json(webhookDeliveryService.getStats());
 });
 
 // Delivery log
-webhookAdminRouter.get('/log', (_req: Request, res: Response) => {
+webhookAdminRouter.get('/log', requireScopes('admin:keys'), (_req: Request, res: Response) => {
   res.json({ attempts: webhookDeliveryService.getDeliveryLog() });
 });


### PR DESCRIPTION
## Summary
- `processWebhookRetry` now looks up the `WebhookRegistration` by `registrationId` and fetches its `url` instead of passing the UUID directly to `fetch`.
- `PATCH /api/v1/keys/:id` now validates the request body against a strict zod allowlist before calling `updateApiKey`, so fields like `keyHash`/`revoked` can no longer be mass-assigned.
- `GET /api/v1/webhooks/dlq/:id` strips `secret`/`apiKey` from the embedded `WebhookRegistration` before serializing the response.
- All `webhookAdmin.ts` routes now require the `admin:keys` scope via `requireScopes`, closing the missing scope-enforcement gap.

Closes #195
Closes #194
Closes #193
Closes #192

## Test plan
- `npm run build --workspace api` passes with no type errors.
- Tests were intentionally skipped per task scope.