### PR TITLE
Fix/monitoring dockerfile fuzz deploy script

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -20,3 +20,36 @@ jobs:
     - run: npm ci
     - name: Run Fuzz Tests
       run: npm run test --workspace=sdk -- --run tests/fuzz.test.ts
+
+  rust-fuzz:
+    name: Rust Fuzz Targets (5-minute budget)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly (required by cargo-fuzz)
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('contracts/onboarding-bridge/fuzz/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-fuzz-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run fuzz_fee_calculation (5 min)
+        run: cargo fuzz run fuzz_fee_calculation -- -max_total_time=300
+        working-directory: contracts/onboarding-bridge
+
+      - name: Run fuzz_fund_sequence (5 min)
+        run: cargo fuzz run fuzz_fund_sequence -- -max_total_time=300
+        working-directory: contracts/onboarding-bridge
+
+      - name: Run fuzz_admin_ops (5 min)
+        run: cargo fuzz run fuzz_admin_ops -- -max_total_time=300
+        working-directory: contracts/onboarding-bridge

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,7 +37,7 @@ COPY sdk/src/ sdk/src/
 RUN npm ci
 
 # Expose API port
-EXPOSE 3000
+EXPOSE 3001
 
 # Set development environment
 ENV NODE_ENV=development

--- a/monitoring/grafana/dashboards/business-kpis.json
+++ b/monitoring/grafana/dashboards/business-kpis.json
@@ -31,7 +31,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "increase(bridge_funding_transactions_total{job=\"c-address-bridge\"}[24h])",
+          "expr": "increase(funding_operations_total{job=\"c-address-bridge\"}[24h])",
           "legendFormat": "24h Volume"
         }
       ],
@@ -47,7 +47,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "increase(bridge_funding_transactions_total{job=\"c-address-bridge\"}[7d])",
+          "expr": "increase(funding_operations_total{job=\"c-address-bridge\"}[7d])",
           "legendFormat": "7d Volume"
         }
       ],
@@ -63,7 +63,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "increase(bridge_funding_transactions_total{job=\"c-address-bridge\"}[30d])",
+          "expr": "increase(funding_operations_total{job=\"c-address-bridge\"}[30d])",
           "legendFormat": "30d Volume"
         }
       ],
@@ -79,7 +79,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "bridge_accumulated_fees_total{job=\"c-address-bridge\"}",
+          "expr": "fee_collected_total{job=\"c-address-bridge\"}",
           "legendFormat": "Fees Collected"
         }
       ],
@@ -94,7 +94,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(bridge_funding_transactions_total{job=\"c-address-bridge\"}[5m])) by (status)",
+          "expr": "sum(rate(funding_operations_total{job=\"c-address-bridge\"}[5m])) by (status)",
           "legendFormat": "{{status}}"
         }
       ],
@@ -110,7 +110,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(bridge_funding_transactions_total{job=\"c-address-bridge\"}[24h])) by (source)",
+          "expr": "sum(increase(funding_operations_total{job=\"c-address-bridge\"}[24h])) by (source)",
           "legendFormat": "{{source}}"
         }
       ],
@@ -125,7 +125,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "bridge_active_funders{job=\"c-address-bridge\"}",
+          "expr": "unique_funders_24h{job=\"c-address-bridge\"}",
           "legendFormat": "Active Funders"
         }
       ],
@@ -141,7 +141,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(bridge_cex_withdrawals_total{job=\"c-address-bridge\"}[24h])) by (exchange)",
+          "expr": "sum(increase(exchange_routing_total{job=\"c-address-bridge\"}[24h])) by (exchange)",
           "legendFormat": "{{exchange}}"
         }
       ],
@@ -157,7 +157,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(increase(bridge_onramp_transactions_total{job=\"c-address-bridge\"}[24h])) by (provider)",
+          "expr": "sum(increase(onramp_requests_total{job=\"c-address-bridge\"}[24h])) by (provider)",
           "legendFormat": "{{provider}}"
         }
       ],
@@ -172,7 +172,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(bridge_funding_volume_usd_total{job=\"c-address-bridge\"}[1h])) * 3600",
+          "expr": "sum(rate(funding_volume_xlm_total{job=\"c-address-bridge\"}[1h])) * 3600",
           "legendFormat": "Volume/hour USD"
         }
       ],

--- a/monitoring/grafana/dashboards/defi-operations.json
+++ b/monitoring/grafana/dashboards/defi-operations.json
@@ -29,8 +29,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(soroban_contract_calls_total{job=\"c-address-bridge\"}[5m])) by (function)",
-          "legendFormat": "{{function}}"
+          "expr": "sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m])) by (service)",
+          "legendFormat": "{{service}}"
         }
       ],
       "title": "Smart Contract Interaction Rate by Function",
@@ -44,18 +44,18 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "histogram_quantile(0.50, sum(rate(soroban_rpc_duration_seconds_bucket{job=\"c-address-bridge\"}[5m])) by (le, endpoint))",
-          "legendFormat": "p50 {{endpoint}}"
+          "expr": "histogram_quantile(0.50, sum(rate(external_api_call_duration_seconds_bucket{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m])) by (le, service))",
+          "legendFormat": "p50 {{service}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "histogram_quantile(0.95, sum(rate(soroban_rpc_duration_seconds_bucket{job=\"c-address-bridge\"}[5m])) by (le, endpoint))",
-          "legendFormat": "p95 {{endpoint}}"
+          "expr": "histogram_quantile(0.95, sum(rate(external_api_call_duration_seconds_bucket{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m])) by (le, service))",
+          "legendFormat": "p95 {{service}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "histogram_quantile(0.99, sum(rate(soroban_rpc_duration_seconds_bucket{job=\"c-address-bridge\"}[5m])) by (le, endpoint))",
-          "legendFormat": "p99 {{endpoint}}"
+          "expr": "histogram_quantile(0.99, sum(rate(external_api_call_duration_seconds_bucket{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m])) by (le, service))",
+          "legendFormat": "p99 {{service}}"
         }
       ],
       "title": "Soroban RPC Latency",
@@ -69,7 +69,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(soroban_rpc_errors_total{job=\"c-address-bridge\"}[5m])) / sum(rate(soroban_rpc_calls_total{job=\"c-address-bridge\"}[5m]))",
+          "expr": "sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\",status=\"error\"}[5m])) / sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m]))",
           "legendFormat": "RPC Error Rate"
         }
       ],
@@ -84,13 +84,13 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(soroban_contract_calls_total{job=\"c-address-bridge\",status=\"success\"}[5m])) by (function)",
-          "legendFormat": "success {{function}}"
+          "expr": "sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\",status=\"success\"}[5m])) by (service)",
+          "legendFormat": "success {{service}}"
         },
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "sum(rate(soroban_contract_calls_total{job=\"c-address-bridge\",status=\"error\"}[5m])) by (function)",
-          "legendFormat": "error {{function}}"
+          "expr": "sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\",status=\"error\"}[5m])) by (service)",
+          "legendFormat": "error {{service}}"
         }
       ],
       "title": "Contract Call Success vs Error",
@@ -105,7 +105,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "soroban_rpc_pool_size{job=\"c-address-bridge\"}",
+          "expr": "count(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\"})",
           "legendFormat": "Pool Size"
         }
       ],
@@ -121,7 +121,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "soroban_rpc_pool_active{job=\"c-address-bridge\"}",
+          "expr": "sum(rate(external_api_call_duration_seconds_count{job=\"c-address-bridge\",service=~\"soroban.*\"}[1m]))",
           "legendFormat": "Active RPC Connections"
         }
       ],
@@ -137,7 +137,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "increase(bridge_fee_withdrawals_total{job=\"c-address-bridge\"}[24h])",
+          "expr": "increase(fee_collected_total{job=\"c-address-bridge\"}[24h])",
           "legendFormat": "Fee Withdrawals (24h)"
         }
       ],
@@ -152,8 +152,8 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "avg(soroban_rpc_duration_seconds{job=\"c-address-bridge\",quantile=\"0.99\"}) by (node)",
-          "legendFormat": "p99 {{node}}"
+          "expr": "histogram_quantile(0.99, sum(rate(external_api_call_duration_seconds_bucket{job=\"c-address-bridge\",service=~\"soroban.*\"}[5m])) by (le, service))",
+          "legendFormat": "p99 {{service}}"
         }
       ],
       "title": "RPC Latency per Node",

--- a/monitoring/grafana/dashboards/system-health.json
+++ b/monitoring/grafana/dashboards/system-health.json
@@ -136,7 +136,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "bridge_active_connections{job=\"c-address-bridge\"}",
+          "expr": "http_active_requests{job=\"c-address-bridge\"}",
           "legendFormat": "Active Connections"
         }
       ],
@@ -152,7 +152,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "bridge_cache_hit_ratio{job=\"c-address-bridge\"}",
+          "expr": "cache_hit_ratio{job=\"c-address-bridge\"}",
           "legendFormat": "Cache Hit Ratio"
         }
       ],
@@ -168,7 +168,7 @@
       "targets": [
         {
           "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-          "expr": "bridge_circuit_breaker_state{job=\"c-address-bridge\"}",
+          "expr": "circuit_breaker_state{job=\"c-address-bridge\"}",
           "legendFormat": "{{service}}"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "secrets:decrypt": "node scripts/secrets.mjs decrypt",
     "secrets:rotate": "node scripts/secrets.mjs rotate",
     "secrets:schema": "node scripts/secrets.mjs schema",
-    "secrets:scan:all": "node scripts/secrets.mjs scan --all"
+    "secrets:scan:all": "node scripts/secrets.mjs scan --all",
+    "deploy:blue-green": "bash scripts/blue-green-deploy.sh"
   },
   "dependencies": {
     "ioredis": "^5.11.1"


### PR DESCRIPTION
closes #297
closes #298
closes #299
closes #300
The alert rules and dashboards use metric names like bridge_circuit_breaker_state, bridge_cache_hit_ratio, soroban_rpc_duration_seconds, etc. None of these exist in api/src/services/metrics.ts — the real names have no bridge_/soroban_ prefix, and no soroban_* metrics exist at all. Runbooks send on-call engineers to these exact dashboards by UID, so the documented incident-response path shows empty panels for what it tells responders to check.


The fuzz README states a 5-minute CI budget gating PRs on all three Rust fuzz targets passing. But fuzz.yml only runs the SDK's JS/fast-check fuzz test — there is no cargo run --bin fuzz_* anywhere in any workflow. The financial-logic fuzz harness for the actual smart contract never executes in CI (and per a related issue, two of the three targets don't even compile currently).

README tells users to run npm run deploy:blue-green, but root package.json's scripts block has no such entry — running the documented command fails with "Missing script".