### PR TITLE
Fix/docs and config issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,85 @@ ASYNC_PIPELINE_ENABLED=true
 ASYNC_BACKPRESSURE_THRESHOLD=1000
 # How long (ms) analytics events are buffered before flushing as a batch job
 ASYNC_BUFFER_FLUSH_MS=100
+
+# Transak webhook secret (must match the value configured in the Transak dashboard)
+TRANSAK_WEBHOOK_SECRET=
+
+# RPC pool tuning
+# Health-check cadence (ms) — how often each RPC endpoint is probed
+RPC_HEALTH_CHECK_INTERVAL_MS=30000
+# Consecutive failures before an endpoint is marked down
+RPC_FAILURE_THRESHOLD=3
+# How long (ms) a down endpoint waits before re-entering rotation
+RPC_RECOVERY_INTERVAL_MS=60000
+# Endpoint selection strategy: round-robin | latency | random
+RPC_SELECTION_STRATEGY=round-robin
+
+# Logging / redaction
+# Service name stamped on every log line
+LOG_SERVICE_NAME=bridge-api
+# App version stamped on every log line (defaults to package.json version)
+APP_VERSION=0.1.0
+# Comma-separated list of field names to redact from logged request/response bodies
+LOG_SENSITIVE_FIELDS=apiKey,api_key,secret,secretKey,password,token,walletAddress,email,privateKey,mnemonic,authorization,x-api-key
+# Maximum characters of a request/response body logged before truncation
+LOG_BODY_TRUNCATE_LENGTH=200
+
+# Rate limiting
+# Set to true to force Redis-backed rate limiting even when REDIS_URL is not set;
+# set to false to use in-memory rate limiting when Redis is unavailable
+REDIS_RATE_LIMIT=false
+# Sliding-window duration in milliseconds
+RATE_LIMIT_WINDOW_MS=60000
+# Multiplier applied to the base per-key rate limit to allow short bursts
+RATE_LIMIT_BURST_FACTOR=2
+
+# Observability — OpenTelemetry + Loki
+# Set to false to disable OpenTelemetry tracing entirely
+OTEL_ENABLED=true
+# OTLP/HTTP collector endpoint for traces
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+# Fraction of traces to sample (0.0–1.0); 0.1 = 10 %
+OTEL_TRACE_SAMPLE_RATIO=0.1
+# Loki push API URL; leave empty to disable log shipping to Loki
+LOKI_PUSH_URL=
+# Internal alert webhook URL for abuse / anomaly notifications; leave empty to disable
+ADMIN_ALERT_URL=
+
+# Compression
+# Minimum response body size in bytes before gzip compression is applied
+COMPRESSION_THRESHOLD_BYTES=1024
+# zlib compression level (1 = fastest, 9 = best compression, 6 = default)
+COMPRESSION_LEVEL=6
+
+# RBAC
+# Set to false to disable role-based access control (all authenticated requests are treated as admin)
+RBAC_ENABLED=true
+
+# Graceful shutdown
+# Time (ms) to wait for in-flight requests to finish before forcing exit
+GRACEFUL_SHUTDOWN_TIMEOUT_MS=30000
+
+# WebSocket
+# Set to false to allow unauthenticated WebSocket connections (development only)
+WS_AUTH_REQUIRED=true
+# Maximum number of topic subscriptions allowed per WebSocket connection
+WS_MAX_SUBSCRIPTIONS=10
+
+# Background jobs (requires REDIS_URL to be set)
+# Set to false to disable the BullMQ worker entirely
+JOBS_ENABLED=true
+# How often (ms) the tx-status polling job runs
+JOB_TX_POLL_INTERVAL_MS=60000
+# How often (ms) the metrics aggregation job runs
+JOB_METRICS_INTERVAL_MS=3600000
+# How often (ms) the database cleanup job runs
+JOB_CLEANUP_INTERVAL_MS=86400000
+# Concurrency limits per job processor
+JOB_CONCURRENCY_TX_STATUS=5
+JOB_CONCURRENCY_WEBHOOK_RETRY=3
+JOB_CONCURRENCY_CACHE_WARMUP=2
+JOB_CONCURRENCY_METRICS=1
+JOB_CONCURRENCY_CLEANUP=1
+JOB_CONCURRENCY_ASYNC_AUDIT=2
+JOB_CONCURRENCY_ASYNC_PIPELINE=5

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+---
+
+## [0.1.0] — 2026-07-29
+
+### Added
+- Soroban onboarding-bridge smart contract with fee-based fund routing
+- Express API with versioned REST endpoints (`/api/v1`)
+- RBAC-backed authentication and per-scope authorization
+- WebSocket server with auth-gated subscription support
+- Redis-backed caching with per-resource TTLs and in-process fallback
+- BullMQ background-jobs subsystem (tx-status polling, webhook retry, cache warmup, metrics, cleanup, async audit)
+- Async processing pipeline with backpressure threshold
+- Idempotency key enforcement on `POST /api/v1/fund`
+- Webhook delivery with HMAC-SHA256 signing and retry logic
+- MoonPay and Transak offramp integrations with webhook verification
+- CEX withdrawal routing (Binance, Coinbase, Kraken) with signed requests
+- RPC pool with round-robin / latency / random selection strategy and circuit breaker
+- OpenTelemetry tracing and Loki log shipping
+- Response compression with configurable threshold
+- Graceful shutdown with configurable timeout
+- Multi-migration database schema with query-optimisation indexes
+- k6 load-test script with ramp-up/steady/ramp-down stages and p95 < 500 ms threshold
+- Rate limiting with optional Redis store and per-key burst factor
+- Correlation-ID middleware for distributed tracing
+- Audit log with integrity verification
+- Fuzz targets for admin ops, fee calculation, and fund sequence (Rust)
+- CI pipelines: tests, security scanning, container security, benchmarks, fuzz, deploy, rollback
+
+### Fixed
+- RBAC double-auth removed; fee-basis-point validation bounds enforced
+- CEX secrets registered correctly; Soroban XDR validator wired
+- Versioning middleware deduplicated; CIDR /0 mask corrected; IPv6 CIDR support added
+- Webhook log headers masked; request-body redaction filter applied consistently
+- Dead middleware and configuration code removed
+
+[Unreleased]: https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge-Backend/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge-Backend/releases/tag/v0.1.0

--- a/docs/load-testing-k6.md
+++ b/docs/load-testing-k6.md
@@ -1,11 +1,110 @@
-## Load Testing Infrastructure Plan
+# Load Testing with k6
 
-This document captures the planned load testing infrastructure for issue #69.
+This document describes the k6 load test that is implemented and running in CI via
+[`.github/workflows/benchmark.yml`](../.github/workflows/benchmark.yml).
 
-- Add k6 as a development dependency
-- Implement spike, sustained, mixed, and endurance scenarios
-- Measure p50/p95/p99 latency, throughput, and error rate
-- Define SLOs: p95 < 500ms, error rate < 0.1%
-- Enable CI-on-demand execution and report generation
-- Document cold and warm cache test strategies
+---
 
+## What Is Tested
+
+The script (`api/tests/performance.k6.js`) runs a single **ramp-up → steady-state → ramp-down** scenario against two endpoints:
+
+| Endpoint | Check |
+|---|---|
+| `GET /health/live` | HTTP 200 |
+| `GET /api/v1/quote?sourceAsset=XLM&amount=1000000&targetAddress=<addr>` | HTTP 200 + body contains `estimatedFee`, `expectedReceive`, `feeBps` |
+
+### Stages
+
+| Stage | Duration | Virtual Users |
+|---|---|---|
+| Ramp-up | 20 s | 0 → `TARGET_VUS` |
+| Steady state | `STEADY_SECONDS` (default `40s`) | `TARGET_VUS` (default `1` or `20` with prefix) |
+| Ramp-down | 20 s | `TARGET_VUS` → 0 |
+
+### Thresholds
+
+| Metric | Threshold |
+|---|---|
+| `http_req_duration` p95 | < 500 ms |
+| `http_req_failed` rate | < 1 % |
+| `checks` pass rate | > 99 % |
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `API_BASE_URL` | `http://localhost:3001` | Base URL of the API under test |
+| `API_KEY` | `benchmark-api-key` | `X-API-Key` header value (single key mode) |
+| `API_KEY_PREFIX` | *(empty)* | When set, each VU uses `<prefix><vu-number>` as its key |
+| `K6_TARGET_VUS` | `1` (or `20` when `API_KEY_PREFIX` is set) | Peak virtual-user count |
+| `K6_STEADY_SECONDS` | `40s` | Duration of the steady-state stage |
+| `K6_SLEEP_SECONDS` | `3` | Think-time sleep between iterations (seconds) |
+
+---
+
+## Running Locally
+
+### Prerequisites
+
+Install k6: https://grafana.com/docs/k6/latest/set-up/install-k6/
+
+```bash
+# macOS (Homebrew)
+brew install k6
+
+# Linux (Debian/Ubuntu)
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+```
+
+### Start the API
+
+```bash
+docker compose up -d
+```
+
+### Run the test (defaults — 1 VU, warm cache)
+
+```bash
+k6 run api/tests/performance.k6.js
+```
+
+### Run with higher concurrency
+
+```bash
+K6_TARGET_VUS=20 K6_STEADY_SECONDS=60s k6 run api/tests/performance.k6.js
+```
+
+### Run against a remote environment
+
+```bash
+API_BASE_URL=https://api.staging.example.com \
+API_KEY=your-staging-key \
+K6_TARGET_VUS=50 \
+k6 run api/tests/performance.k6.js
+```
+
+---
+
+## CI Execution
+
+The `benchmark.yml` workflow runs this test on demand (workflow dispatch) or on pushes that
+touch the API source. It passes `API_BASE_URL` and `API_KEY` from repository secrets and
+uploads the k6 summary JSON as a workflow artifact.
+
+---
+
+## Interpreting Results
+
+k6 prints a summary at the end of the run. Look for:
+
+- **`http_req_duration`** — latency distribution (p50/p90/p95/p99)
+- **`http_req_failed`** — fraction of requests that returned a non-2xx status or a network error
+- **`checks`** — pass rate for the inline assertions
+
+A run is considered passing when all three thresholds above are met (shown as `✓` in the
+summary). A failed threshold exits with a non-zero code, which fails the CI job.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "sdk"
   ],
   "scripts": {
+    "prepare": "husky",
     "build": "npm run build --workspaces",
     "test": "npm run test --workspaces",
     "test:e2e": "npm run test:e2e --workspace api",
@@ -24,6 +25,7 @@
     "ioredis": "^5.11.1"
   },
   "devDependencies": {
+    "husky": "^9.1.7",
     "lint-staged": "^15.2.10"
   },
   "lint-staged": {


### PR DESCRIPTION
closes #305
closes #306 
closes #307 
closes #308 

The doc reads as a TODO list ("planned load testing infrastructure for issue #69"), but k6 load testing is already implemented and running in benchmark.yml. The actual script implements one ramp-up/steady/ramp-down stage against /health/live and /quote — not the "spike, sustained, mixed, endurance" scenarios the doc claims are planned — and the doc never documents what was actually built.


Entire config sections have zero representation in .env.example: RPC pool tuning, logging/redaction, rate-limit Redis toggle, observability (OTel/Loki), compression, RBAC_ENABLED, graceful shutdown timeout, WebSocket auth, and the entire background-jobs subsystem (JOBS_ENABLED plus multiple concurrency vars). TRANSAK_WEBHOOK_SECRET is also missing despite being set explicitly in CI.

