### PR TITLE
Fix/env parameterization and adr updates

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ This directory captures the key architectural decisions for the C-Address Onboar
 - [ADR-007: Use Stellar and soroban-sdk v26](adr-007-use-stellar-and-soroban-sdk-v26.md)
 - [ADR-008: Event-driven architecture for status updates](adr-008-event-driven-architecture-for-status-updates.md)
 - [ADR-009: Security architecture — defense-in-depth](adr-009-security-architecture.md)
+- [ADR-010: Transition to persistent PostgreSQL database](adr-010-transition-to-persistent-postgres-database.md)
 
 ## ADR Template
 

--- a/docs/adr/adr-002-stateless-api-server-with-no-database.md
+++ b/docs/adr/adr-002-stateless-api-server-with-no-database.md
@@ -22,3 +22,12 @@ Run the API server as a stateless service without a persistent database in the i
 ## Related ADRs
 - [ADR-001: Use Soroban for smart contract execution](adr-001-use-soroban-for-smart-contract-execution.md)
 - [ADR-008: Event-driven architecture for status updates](adr-008-event-driven-architecture-for-status-updates.md)
+- [ADR-010: Transition to persistent PostgreSQL database](adr-010-transition-to-persistent-postgres-database.md)
+
+---
+
+## Addendum — decision superseded
+
+> Status: **Superseded by ADR-010**
+
+This decision no longer reflects the current architecture. The codebase has since introduced a full PostgreSQL-backed persistence layer: `api/src/services/db.ts`, a migration runner (`api/src/migrations/`), and a `DATABASE_URL` config block consumed by the deploy pipeline for every environment. See [ADR-010](adr-010-transition-to-persistent-postgres-database.md) for the rationale and transition details.

--- a/docs/adr/adr-008-event-driven-architecture-for-status-updates.md
+++ b/docs/adr/adr-008-event-driven-architecture-for-status-updates.md
@@ -5,14 +5,14 @@
 - Date: 2026-06-29
 
 ## Context
-The bridge needs to surface progress and lifecycle updates for deposits, transfers, and off-ramp events. A simple request-response model is insufficient for long-running workflows and future real-time experiences.
+The bridge needs to surface progress and lifecycle updates for deposits, transfers, and off-ramp events. A simple request-response model is insufficient for long-running workflows and real-time experiences.
 
 ## Decision
-Adopt an event-driven architecture for status updates, with a clear path to WebSocket delivery once the platform needs live push notifications.
+Adopt an event-driven architecture for status updates, with WebSocket delivery for live push notifications. WebSocket support is implemented and live: `api/src/services/websocket.ts` mounts a `/ws` upgrade endpoint backed by the `ws` production dependency, with a dedicated test suite in `api/src/__tests__/websocket.test.ts`.
 
 ## Consequences
 - Supports asynchronous workflows and better observability.
-- Makes it easier to add future real-time clients.
+- Real-time clients are supported today via the WebSocket endpoint.
 - Adds some complexity around event schema versioning and delivery guarantees.
 
 ## Alternatives considered

--- a/docs/adr/adr-010-transition-to-persistent-postgres-database.md
+++ b/docs/adr/adr-010-transition-to-persistent-postgres-database.md
@@ -1,0 +1,41 @@
+# ADR-010: Transition to persistent PostgreSQL database
+
+- Title: Transition to persistent PostgreSQL database
+- Status: Accepted
+- Date: 2026-07-29
+- Supersedes: [ADR-002: Stateless API server with no database](adr-002-stateless-api-server-with-no-database.md)
+
+## Context
+ADR-002 deliberately deferred database adoption to keep the initial deployment simple and stateless. As the platform matured, several requirements made a persistent store unavoidable:
+
+- **API key management** — issuing, rotating, and revoking API keys requires durable storage that survives restarts and scales across instances.
+- **Audit logging with integrity guarantees** — `docs/audit-log-integrity.md` describes append-only tamper-evident logs that cannot live only in memory or on-chain.
+- **Analytics and query history** — the analytics schema (`003_analytics_schema.ts`) records transaction-level data needed for reporting and abuse detection that the Soroban contract does not expose.
+- **Idempotency keys** — preventing duplicate fund/offramp submissions across retried requests requires a shared, durable key store.
+- **Webhook delivery tracking** — `api/src/services/webhookDelivery.ts` records delivery attempts and retries, which must outlive any single API process.
+
+The deploy pipeline (`deploy.yml`) already runs `DATABASE_URL`-backed migrations against all three environments on every deploy, confirming the database is a first-class runtime dependency.
+
+## Decision
+Adopt PostgreSQL as the persistent data store for the API. The implementation uses:
+
+- `api/src/services/db.ts` — connection pool and query interface
+- `api/src/migrations/` — versioned migration runner (`001` through `005`) covering the initial schema, API keys, analytics, audit-log integrity, and query-optimisation indexes
+- `api/src/migrations/runner.ts` — runs pending migrations at startup; `api/scripts/migrate.ts` provides a standalone CLI entrypoint
+- `infrastructure/main.tf` — provisions the RDS instance; `DATABASE_URL` is injected per environment via Secrets Manager
+
+## Consequences
+- Horizontal scaling still works: the connection pool is stateless across pods; state lives in RDS.
+- Schema changes require migrations; the runner enforces ordering and idempotency.
+- Operational overhead increases: RDS provisioning, backups, failover, and connection-pool sizing must be managed.
+- The service is no longer restartable without a database — `DATABASE_URL` is a hard runtime requirement in all environments.
+- `docs/database.md` documents the operational model, backup strategy, and connection-pool configuration.
+
+## Alternatives considered
+- Continue deferring the database and storing API keys/audit records in external services (e.g., DynamoDB, Redis). Rejected: adds more vendor dependencies and does not support relational queries needed for analytics.
+- Use a managed serverless database (Aurora Serverless). Not chosen for the initial rollout due to cold-start latency concerns, but remains a valid upgrade path.
+
+## Related ADRs
+- [ADR-002: Stateless API server with no database](adr-002-stateless-api-server-with-no-database.md) — superseded by this decision
+- [ADR-001: Use Soroban for smart contract execution](adr-001-use-soroban-for-smart-contract-execution.md)
+- [ADR-009: Security architecture — defense-in-depth](adr-009-security-architecture.md)

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -20,14 +20,14 @@ provider "aws" {
 
 # ECS Cluster
 resource "aws_ecs_cluster" "main" {
-  name = "c-address-cluster"
+  name = "c-address-cluster-${var.environment}"
 }
 
 # RDS PostgreSQL
 resource "aws_db_instance" "postgres" {
-  identifier           = "c-address-db"
+  identifier           = "c-address-db-${var.environment}"
   engine               = "postgres"
-  instance_class       = "db.t3.micro"
+  instance_class       = var.db_instance_class
   allocated_storage    = 20
   db_name              = "caddress"
   username             = var.db_username
@@ -37,9 +37,9 @@ resource "aws_db_instance" "postgres" {
 
 # Redis ElastiCache
 resource "aws_elasticache_cluster" "redis" {
-  cluster_id           = "c-address-redis"
+  cluster_id           = "c-address-redis-${var.environment}"
   engine               = "redis"
-  node_type            = "cache.t3.micro"
+  node_type            = var.redis_node_type
   num_cache_nodes      = 1
   port                 = 6379
 }
@@ -49,5 +49,5 @@ resource "aws_elasticache_cluster" "redis" {
 
 # Secrets Manager
 resource "aws_secretsmanager_secret" "api_secrets" {
-  name = "c-address-api-secrets"
+  name = "c-address-api-secrets-${var.environment}"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -4,6 +4,12 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
+variable "environment" {
+  description = "Deployment environment (e.g. dev, staging, production). Used to namespace resource identifiers and prevent state collisions across environments."
+  type        = string
+  default     = "production"
+}
+
 variable "db_username" {
   description = "Database administrator username"
   type        = string
@@ -14,4 +20,16 @@ variable "db_password" {
   description = "Database administrator password"
   type        = string
   sensitive   = true
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class (e.g. db.t3.micro for dev, db.t3.medium for staging/production)"
+  type        = string
+  default     = "db.t3.micro"
+}
+
+variable "redis_node_type" {
+  description = "ElastiCache node type (e.g. cache.t3.micro for dev, cache.t3.small for staging/production)"
+  type        = string
+  default     = "cache.t3.micro"
 }


### PR DESCRIPTION
closes #309
closes #310
closes #311
closes #312


main.tf hardcodes identifiers like c-address-db/c-address-redis and instance sizes with no environment variable, unlike the CDN module which properly parametrizes on var.environment. This means the same Terraform state would collide across dev/staging/production, contradicting the deploy pipeline's explicit 3-environment model.


main.tf defines only an empty aws_ecs_cluster resource — no aws_ecs_service, task definition, VPC/subnet resources, security groups, or load balancer exist anywhere in infrastructure/*.tf, even though the CDN module's variables expect an ALB DNS name to exist. terraform apply on this config provisions an empty, non-functional ECS cluster.


ADR-002 states flatly that the API runs without a persistent database. The codebase now has a full Postgres migration system, a dedicated db.ts service, and a database config block, with deploy.yml running migrations against DATABASE_URL for every environment. docs/database.md itself acknowledges the tension, but ADR-002 was never updated and still reads as final, settled fact.