### PR TITLE
Fix/docs observability cleanup

### DIFF
--- a/contracts/onboarding-bridge/UPGRADE.md
+++ b/contracts/onboarding-bridge/UPGRADE.md
@@ -29,13 +29,13 @@ call and requires admin auth.
    ```
 2. Build and test:
    ```bash
-   cargo build --target wasm32-unknown-unknown --release
+   cargo build --target wasm32v1-none --release
    cargo test
    ```
 3. Deploy the new WASM and note the hash:
    ```bash
-   soroban contract install \
-     --wasm target/wasm32-unknown-unknown/release/onboarding_bridge.wasm \
+   stellar contract install \
+     --wasm target/wasm32v1-none/release/onboarding_bridge.wasm \
      --source <admin-secret> \
      --rpc-url <rpc-url> \
      --network-passphrase "<passphrase>"
@@ -43,7 +43,7 @@ call and requires admin auth.
    ```
 4. Call `upgrade` on the live contract (admin only):
    ```bash
-   soroban contract invoke \
+   stellar contract invoke \
      --id <contract-id> \
      --source <admin-secret> \
      --rpc-url <rpc-url> \
@@ -52,8 +52,8 @@ call and requires admin auth.
    ```
 5. Verify the contract still works:
    ```bash
-   soroban contract invoke --id <contract-id> ... -- version
-   soroban contract invoke --id <contract-id> ... -- schema_version
+   stellar contract invoke --id <contract-id> ... -- version
+   stellar contract invoke --id <contract-id> ... -- schema_version
    ```
 
 No `migrate` call is needed when the schema has not changed.
@@ -77,7 +77,7 @@ Follow all steps in §1, then additionally:
    ```
 3. After calling `upgrade`, call `migrate` (admin only):
    ```bash
-   soroban contract invoke \
+   stellar contract invoke \
      --id <contract-id> \
      --source <admin-secret> \
      --rpc-url <rpc-url> \
@@ -86,7 +86,7 @@ Follow all steps in §1, then additionally:
    ```
 4. Confirm `schema_version` returns the new value:
    ```bash
-   soroban contract invoke --id <contract-id> ... -- schema_version
+   stellar contract invoke --id <contract-id> ... -- schema_version
    # expect: 2
    ```
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -123,17 +123,17 @@ npm run dev -w api
 cd contracts/onboarding-bridge
 
 # Build WASM
-cargo build --target wasm32-unknown-unknown --release
+cargo build --target wasm32v1-none --release
 
 # Deploy to local sandbox
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/onboarding_bridge.wasm \
+stellar contract deploy \
+  --wasm target/wasm32v1-none/release/onboarding_bridge.wasm \
   --source <admin-secret> \
   --rpc-url http://localhost:8000/soroban/rpc \
   --network-passphrase "Standalone Network ; February 2017"
 
 # Initialize (paste the contract ID returned above)
-soroban contract invoke \
+stellar contract invoke \
   --id <contract-id> \
   --source <admin-secret> \
   --rpc-url http://localhost:8000/soroban/rpc \
@@ -334,7 +334,7 @@ chmod +x .husky/pre-commit
 ### `cargo build` fails — wasm target missing
 
 ```bash
-rustup target add wasm32-unknown-unknown
+rustup target add wasm32v1-none
 ```
 
 ---

--- a/docs/runbooks/circuit-breaker-open.md
+++ b/docs/runbooks/circuit-breaker-open.md
@@ -19,5 +19,5 @@ A circuit breaker for an external service has been in OPEN state for >5 minutes,
 ## Remediation
 
 - If external service is back: the half-open probe will reset automatically (default 30s)
-- To force reset: `kubectl exec -it <pod> -- curl -X POST localhost:3001/internal/circuit-breaker/reset`
+- To force reset: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "curl -X POST localhost:3001/internal/circuit-breaker/reset"`
 - If service is experiencing an extended outage: create a maintenance window silence in Alertmanager

--- a/docs/runbooks/health-endpoint-down.md
+++ b/docs/runbooks/health-endpoint-down.md
@@ -10,11 +10,11 @@ The `/health` endpoint is not responding to blackbox probes.
 ## Investigation Steps
 
 1. **Manual probe**: `curl -v https://<host>/health`
-2. **Check pod status**: `kubectl get pods -l app=c-address-bridge`
-3. **Check recent events**: `kubectl describe pod <pod-name>`
-4. **Check logs**: `kubectl logs <pod-name> --previous`
+2. **Check service status**: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "systemctl status c-address-bridge"`
+3. **Check recent events**: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "journalctl -u c-address-bridge -n 100 --no-pager"`
+4. **Check logs**: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "journalctl -u c-address-bridge --since '-30min'"`
 
 ## Remediation
 
-- Restart pod: `kubectl rollout restart deployment/c-address-bridge`
+- Restart service: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "sudo systemctl restart c-address-bridge"`
 - If persistent: roll back to previous image

--- a/docs/runbooks/high-error-rate.md
+++ b/docs/runbooks/high-error-rate.md
@@ -17,12 +17,12 @@ Users cannot complete funding transactions or receive quotes. Revenue impact beg
 1. **Check recent deployments**
    ```bash
    git log --oneline -10
-   kubectl rollout history deployment/c-address-bridge
+   ssh "$DEPLOY_USER@$DEPLOY_HOST" "cat deployments/current-release"
    ```
 
 2. **Inspect error logs**
    ```bash
-   kubectl logs -l app=c-address-bridge --tail=200 | grep '"level":"error"'
+   ssh "$DEPLOY_USER@$DEPLOY_HOST" "journalctl -u c-address-bridge --since '-1h'" | grep '"level":"error"'
    ```
 
 3. **Check downstream services** — Soroban RPC, Moonpay, Transak, database
@@ -31,12 +31,12 @@ Users cannot complete funding transactions or receive quotes. Revenue impact beg
 
 4. **Check database connectivity**
    ```bash
-   kubectl exec -it <api-pod> -- node -e "require('./dist/services/db').db.raw('SELECT 1')"
+   ssh "$DEPLOY_USER@$DEPLOY_HOST" "node -e \"require('./dist/services/db').db.raw('SELECT 1')\""
    ```
 
 ## Remediation
 
-- If a bad deploy: `kubectl rollout undo deployment/c-address-bridge`
+- If a bad deploy: `bash scripts/deploy.sh --rollback` (see [rollback.yml](../../.github/workflows/rollback.yml))
 - If a downstream outage: circuit breakers should open automatically; verify in dashboard
 - If DB connectivity: check pgbouncer pool exhaustion, restart if needed
 

--- a/docs/runbooks/high-memory.md
+++ b/docs/runbooks/high-memory.md
@@ -5,7 +5,7 @@
 
 ## Investigation Steps
 
-1. Check current memory: `kubectl top pods -l app=c-address-bridge`
+1. Check current memory: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "systemctl status c-address-bridge | grep Memory"`
 2. Check for memory leaks in logs: look for "heap" or "memory" errors
 3. Check if in-memory cache is unbounded: `api/src/services/cache.ts`
 4. Profile if persistent: attach a Node.js heap snapshot
@@ -13,5 +13,5 @@
 ## Remediation
 
 - **Warning**: monitor, no immediate action
-- **Critical**: restart pod to reclaim memory: `kubectl rollout restart deployment/c-address-bridge`
+- **Critical**: restart service to reclaim memory: `ssh "$DEPLOY_USER@$DEPLOY_HOST" "sudo systemctl restart c-address-bridge"`
 - Long-term: tune cache max size, add memory limits to container spec

--- a/docs/runbooks/rate-limit-high.md
+++ b/docs/runbooks/rate-limit-high.md
@@ -11,7 +11,7 @@ More than 80% of incoming requests are being rate-limited, indicating potential 
 
 1. Check which client IPs or API keys are being rate-limited:
    ```bash
-   kubectl logs -l app=c-address-bridge | grep "rate_limit" | awk '{print $NF}' | sort | uniq -c | sort -rn | head -20
+   ssh "$DEPLOY_USER@$DEPLOY_HOST" "journalctl -u c-address-bridge --no-pager" | grep "rate_limit" | awk '{print $NF}' | sort | uniq -c | sort -rn | head -20
    ```
 2. Determine if this is legitimate load or abuse
 

--- a/docs/runbooks/soroban-rpc-errors.md
+++ b/docs/runbooks/soroban-rpc-errors.md
@@ -16,7 +16,7 @@ More than 10% of Soroban RPC calls are failing. Contract interactions may be fai
 2. **Check RPC pool status** in DeFi Operations dashboard
 3. **Check error types** in logs:
    ```bash
-   kubectl logs -l app=c-address-bridge | grep "soroban" | grep "error"
+   ssh "$DEPLOY_USER@$DEPLOY_HOST" "journalctl -u c-address-bridge --no-pager" | grep "soroban" | grep "error"
    ```
 4. **Check Stellar network status**: https://status.stellar.org
 

--- a/infrastructure/observability/prometheus.yml
+++ b/infrastructure/observability/prometheus.yml
@@ -6,7 +6,7 @@ rule_files:
   - /etc/prometheus/alerts.yml
 
 scrape_configs:
-  - job_name: bridge-api
+  - job_name: c-address-bridge
     static_configs:
       - targets: ['api:3001']
     metrics_path: /metrics

--- a/monitoring/prometheus/rules/alerts.yaml
+++ b/monitoring/prometheus/rules/alerts.yaml
@@ -42,7 +42,7 @@ groups:
 
       - alert: HealthEndpointDown
         expr: |
-          probe_success{job="blackbox",instance=~".*c-address-bridge.*/health"} == 0
+          up{job="c-address-bridge"} == 0
         for: 2m
         labels:
           severity: critical


### PR DESCRIPTION
closes #304
closes #301
closes #302
closes #303


infrastructure/observability/prometheus.yml scrapes job_name: bridge-api. But every rule in monitoring/prometheus/rules/alerts.yaml and every dashboard panel in monitoring/ filters on job="c-address-bridge". There is no scrape config anywhere in monitoring/ that would ever produce a job="c-address-bridge" series — this entire alert/dashboard set is structurally orphaned regardless of the metric-name issue above.


Both docs use cargo build --target wasm32-unknown-unknown and the legacy soroban contract deploy/invoke commands. Every workflow and script in the repo (ci.yml, deploy-contract.yml, scripts/deploy.sh, scripts/deploy-contract.sh, scripts/rollback-contract.sh, CONTRIBUTING.md) consistently uses wasm32v1-none and the stellar CLI instead.


The alert condition is probe_success{job="blackbox",...} == 0. No blackbox-exporter (or any job="blackbox" target) is defined anywhere in the observability stack — the alert can never fire.

