### PR TITLE
fix: i18n test coverage, UMD example bundle, and doc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ coverage/
 !.vscode/settings.json
 !.vscode/extensions.json
 test_snapshots/
+__snapshots__/
+*.snap
+.vitest-cache/
+*.tsbuildinfo
 deployments/*.json
 .secrets.local.json
 .secrets.local.enc

--- a/docs/wallet-integration.md
+++ b/docs/wallet-integration.md
@@ -189,10 +189,18 @@ After the user completes the purchase, the provider sends a webhook to the bridg
 
 ## Error Handling
 
-All `BridgeClient` methods throw a native `Error` on failure. The message comes from the API response body when available.
+`BridgeClient` methods throw typed subclasses of `BridgeError` (from `errors.ts`), not a native `Error`. Every error carries a `statusCode`, an optional `code`, and a `retryable` flag, and the SDK exports type guards (`isAuthError`, `isValidationError`, etc.) so you can branch on error type instead of parsing `err.message`.
 
 ```typescript
-import { BridgeClient } from '@c-address-bridge/sdk';
+import {
+  BridgeClient,
+  isAuthError,
+  isValidationError,
+  isRateLimitError,
+  isServerError,
+  isNetworkError,
+  isNotFoundError,
+} from '@c-address-bridge/sdk';
 
 const client = new BridgeClient({ baseUrl: '...', apiKey: '...' });
 
@@ -203,31 +211,42 @@ try {
     targetAddress: 'C...',
   });
 } catch (err) {
-  if (err instanceof Error) {
-    switch (true) {
-      case err.message === 'unauthorized':
-        // Prompt user to re-authenticate or contact support
-        break;
-      case err.message.startsWith('validation_error'):
-        // Show inline field error
-        break;
-      default:
-        // Generic fallback
-        console.error('Bridge error:', err.message);
-    }
+  if (isAuthError(err)) {
+    // Prompt user to re-authenticate or contact support
+  } else if (isValidationError(err)) {
+    // err.fields holds a map of field name -> validation message, when provided
+    console.error('Invalid fields:', err.fields);
+  } else if (isRateLimitError(err)) {
+    // err.retryAfterMs suggests how long to wait before retrying
+    console.error(`Rate limited, retry after ${err.retryAfterMs}ms`);
+  } else if (isNotFoundError(err)) {
+    // Requested resource does not exist
+  } else if (isServerError(err) || isNetworkError(err)) {
+    // err.retryable is true for both — safe to retry with backoff
+    console.error('Transient error, safe to retry:', err.message);
+  } else {
+    console.error('Bridge error:', err);
   }
 }
 ```
 
-Common error messages:
+`BridgeError.isRetryable(err)` is a static helper equivalent to checking `err instanceof BridgeError && err.retryable` — useful in generic retry wrappers that don't need to distinguish error types.
 
-| Message | Cause |
-|---------|-------|
-| `unauthorized` | Missing or invalid `X-API-Key` header |
-| `validation_error` | Invalid query parameter (bad address, missing field, etc.) |
-| `request failed: ...` | HTTP-level failure or network error |
+Typed error classes and their default messages:
 
-Requests time out after **30 seconds**. Implement retry logic with exponential backoff in your application as needed.
+| Class | Default message | statusCode | retryable | Guard |
+|-------|------------------|------------|-----------|-------|
+| `AuthError` | `Unauthorized` | 401 or 403 | `false` | `isAuthError` |
+| `ValidationError` | *(required)* | 400 or 422 | `false` | `isValidationError` |
+| `NotFoundError` | `Not found` | 404 | `false` | `isNotFoundError` |
+| `RateLimitError` | `Too many requests` | 429 | `true` | `isRateLimitError` |
+| `ServerError` | *(required)* | 500+ | `true` | `isServerError` |
+| `NetworkError` | `Network error` | — | `true` | `isNetworkError` |
+| `TimeoutError` | `Operation "{op}" timed out after {ms}ms` | — | `true` | `isTimeoutError` |
+
+All of the above extend `BridgeError`, which itself extends `Error` — `isBridgeError(err)` narrows any thrown value to the base type, and `err instanceof Error` still works for a coarse check.
+
+Requests time out after **30 seconds**, surfaced as a `TimeoutError`. Use the `retryable` flag (or the corresponding type guard) to decide whether to retry with exponential backoff in your application.
 
 ---
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -14,6 +14,39 @@ The payload includes only non-PII metadata such as SDK version, Node.js version,
 
 The SDK ships with an ESM build for bundlers and a UMD bundle for browser script tags. Browser usage requires a global `fetch` implementation in the target environment.
 
+## Quickstart
+
+```ts
+import { BridgeClient } from '@c-address-bridge/sdk';
+
+const client = new BridgeClient({
+  baseUrl: 'https://api.bridge.example.com',
+  apiKey: 'your-api-key',
+});
+
+// 1. Get a fee quote for funding a C-address
+const quote = await client.getQuote({
+  sourceAsset: 'XLM',
+  amount: '10000000',        // 1 XLM in stroops
+  targetAddress: 'C...',
+});
+
+// 2. Prepare an unsigned funding transaction
+const prepared = await client.prepareFundingTransaction({
+  sourceAddress: 'G...',
+  targetAddress: 'C...',
+  tokenAddress: 'CC...',     // SEP-41 token contract address
+  amount: '10000000',
+});
+
+// 3. Sign prepared.instruction with the user's wallet, then submit it
+const result = await client.submitSignedXdr({ signedXdr: '...' });
+
+console.log(result.status); // 'pending' | 'success' | 'failed'
+```
+
+See the [Wallet Integration Guide](../docs/wallet-integration.md) for the full funding flows (G-address, CEX withdrawal, credit card on-ramp) and typed error handling.
+
 ## Testing
 
 The SDK ships with a dedicated testing package at `@c-address-bridge/sdk/testing`. It provides an in-memory mock server that intercepts `fetch` — no real API server or network required.
@@ -108,5 +141,7 @@ expect(req.headers['x-api-key']).toBe('my-api-key');
 | `fixtures.moonpayWidgetResult(overrides?)` | `MoonpayWidgetResult` |
 | `fixtures.transakWidgetResult(overrides?)` | `TransakWidgetResult` |
 | `fixtures.apiError(message, code?)` | `{ message, code? }` |
+| `fixtures.token(overrides?)` | `Token` |
+| `fixtures.tokenMetadata(overrides?)` | `TokenMetadata` |
 
-Pre-built address constants: `MOCK_C_ADDRESS`, `MOCK_G_ADDRESS`, `MOCK_TOKEN_ADDRESS`, `MOCK_TX_HASH`, `MOCK_QUOTE_PARAMS`, `MOCK_FUND_PARAMS`.
+Pre-built constants: `MOCK_C_ADDRESS`, `MOCK_G_ADDRESS`, `MOCK_TOKEN_ADDRESS`, `MOCK_TX_HASH`, `MOCK_QUOTE_PARAMS`, `MOCK_FUND_PARAMS`, `MOCK_NATIVE_TOKEN`, `MOCK_SAC_TOKEN`, `MOCK_TOKEN_METADATA`.

--- a/sdk/scripts/build-bundle.mjs
+++ b/sdk/scripts/build-bundle.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 /**
  * Builds SDK bundles with esbuild for browser consumers.
- * Generates minified ESM bundles and a metafile for size analysis.
+ * Generates minified ESM bundles, a single-file UMD/IIFE bundle
+ * (dist/bridge.umd.js, exposed as window.BridgeSDK) for <script> tag
+ * consumers, and a metafile for size analysis.
  *
  * Usage:
  *   node scripts/build-bundle.mjs           # build only
@@ -64,6 +66,33 @@ for (const [entry, outFile, label] of bundles) {
   const bytes = readFileSync(resolve(outDir, outFile));
   const gz = gzipSync(bytes, { level: 9 });
   results.push({ label, raw: bytes.length, gz: gz.length });
+}
+
+// Single-file UMD/IIFE bundle for <script> tag consumers, exposing a
+// `window.BridgeSDK` global — see sdk/examples/browser.html.
+const umdResult = await esbuild.build({
+  bundle: true,
+  minify: true,
+  format: 'iife',
+  globalName: 'BridgeSDK',
+  platform: 'browser',
+  target: 'es2020',
+  treeShaking: true,
+  legalComments: 'none',
+  entryPoints: [resolve(root, 'src/index.ts')],
+  outfile: resolve(root, 'dist', 'bridge.umd.js'),
+});
+
+if (umdResult.errors.length > 0) {
+  console.error('esbuild errors in umd:');
+  umdResult.errors.forEach((e) => console.error(' ', e.text));
+  process.exit(1);
+}
+
+{
+  const bytes = readFileSync(resolve(root, 'dist', 'bridge.umd.js'));
+  const gz = gzipSync(bytes, { level: 9 });
+  results.push({ label: 'umd (bridge.umd.js)', raw: bytes.length, gz: gz.length });
 }
 
 if (fullMetafile) {

--- a/sdk/src/i18n/fr.ts
+++ b/sdk/src/i18n/fr.ts
@@ -1,0 +1,39 @@
+import type { MessageCatalog } from './types';
+
+/** French (fr) translation catalog. */
+export const fr: MessageCatalog = {
+  'error.unknown':                     'Une erreur inconnue est survenue.',
+  'error.request_failed':              'La requête a échoué avec le statut {{status}}.',
+
+  'error.auth.unauthorized':           'Non autorisé. Vérifiez votre clé API.',
+  'error.auth.forbidden':              'Interdit. Vous n\'avez pas la permission d\'effectuer cette action.',
+
+  'error.validation.invalid_address':  'Adresse invalide : {{address}}.',
+  'error.validation.invalid_amount':   'Montant invalide : {{amount}}. Doit être une chaîne d\'entier positif (stroops).',
+  'error.validation.missing_field':    'Champ requis manquant : {{field}}.',
+  'error.validation.generic':          'Erreur de validation : {{detail}}.',
+
+  'error.not_found':                   'La ressource demandée est introuvable.',
+
+  'error.rate_limit':                  'Trop de requêtes. Veuillez ralentir.',
+  'error.rate_limit.retry_after':      'Trop de requêtes. Réessayez dans {{seconds}} secondes.',
+
+  'error.server':                      'Une erreur serveur est survenue. Veuillez réessayer plus tard.',
+
+  'error.network':                     'Une erreur réseau est survenue. Vérifiez votre connexion et réessayez.',
+  'error.timeout':                     'L\'opération « {{operation}} » a expiré après {{ms}} ms.',
+
+  'error.offline.queued':              'Vous êtes hors ligne. La requête a été mise en file d\'attente et sera relancée dès le rétablissement de la connexion.',
+  'error.offline.not_queued':          'Vous êtes hors ligne. La requête n\'a pas pu être mise en file d\'attente.',
+  'error.queue_full':                  'La file d\'attente hors ligne est pleine (max {{max}} entrées). La requête a été abandonnée.',
+
+  'error.invalid_stellar_address':     '« {{address}} » n\'est pas une adresse Stellar valide.',
+  'error.invalid_c_address':           '« {{address}} » n\'est pas une C-address valide (compte intelligent Soroban).',
+  'error.invalid_g_address':           '« {{address}} » n\'est pas une G-address valide (compte Stellar classique).',
+
+  'error.fee_too_high':                'Les frais de {{feeBps}} bps dépassent le maximum de {{maxBps}} bps.',
+  'error.amount_too_small':            'Le montant {{amount}} est inférieur au minimum de {{min}} stroops.',
+  'error.amount_too_large':            'Le montant {{amount}} dépasse le maximum de {{max}} stroops.',
+
+  'error.unsupported_exchange':        'L\'échange « {{exchange}} » n\'est pas pris en charge.',
+};

--- a/sdk/src/i18n/index.ts
+++ b/sdk/src/i18n/index.ts
@@ -1,0 +1,30 @@
+export type {
+  SupportedLocale,
+  LocaleMetadata,
+  MessageKey,
+  MessageParams,
+  MessageCatalog,
+} from './types';
+export { SUPPORTED_LOCALES, LOCALE_METADATA } from './types';
+
+import type { SupportedLocale, MessageCatalog } from './types';
+import { en } from './en';
+import { es } from './es';
+import { zh } from './zh';
+import { ja } from './ja';
+import { ko } from './ko';
+import { fr } from './fr';
+import { pt } from './pt';
+
+export { en, es, zh, ja, ko, fr, pt };
+
+/** All message catalogs keyed by supported locale. */
+export const MESSAGE_CATALOGS: Record<SupportedLocale, MessageCatalog> = {
+  en,
+  es,
+  zh,
+  ja,
+  ko,
+  fr,
+  pt,
+};

--- a/sdk/src/i18n/ja.ts
+++ b/sdk/src/i18n/ja.ts
@@ -1,0 +1,39 @@
+import type { MessageCatalog } from './types';
+
+/** Japanese (ja) translation catalog. */
+export const ja: MessageCatalog = {
+  'error.unknown':                     '不明なエラーが発生しました。',
+  'error.request_failed':              'リクエストがステータス {{status}} で失敗しました。',
+
+  'error.auth.unauthorized':           '認証されていません。APIキーを確認してください。',
+  'error.auth.forbidden':              'アクセスが禁止されています。この操作を実行する権限がありません。',
+
+  'error.validation.invalid_address':  '無効なアドレスです: {{address}}。',
+  'error.validation.invalid_amount':   '無効な金額です: {{amount}}。正の整数の文字列（stroops）である必要があります。',
+  'error.validation.missing_field':    '必須フィールドがありません: {{field}}。',
+  'error.validation.generic':          '検証エラー: {{detail}}。',
+
+  'error.not_found':                   '要求されたリソースが見つかりませんでした。',
+
+  'error.rate_limit':                  'リクエストが多すぎます。速度を落としてください。',
+  'error.rate_limit.retry_after':      'リクエストが多すぎます。{{seconds}} 秒後に再試行してください。',
+
+  'error.server':                      'サーバーエラーが発生しました。後でもう一度お試しください。',
+
+  'error.network':                     'ネットワークエラーが発生しました。接続を確認して再試行してください。',
+  'error.timeout':                     '操作「{{operation}}」は {{ms}} ミリ秒後にタイムアウトしました。',
+
+  'error.offline.queued':              'オフラインです。リクエストはキューに追加され、接続が復旧次第再試行されます。',
+  'error.offline.not_queued':          'オフラインです。リクエストをキューに追加できませんでした。',
+  'error.queue_full':                  'オフラインキューが満杯です（最大 {{max}} 件）。リクエストは破棄されました。',
+
+  'error.invalid_stellar_address':     '「{{address}}」は有効な Stellar アドレスではありません。',
+  'error.invalid_c_address':           '「{{address}}」は有効な C アドレス（Soroban スマートアカウント）ではありません。',
+  'error.invalid_g_address':           '「{{address}}」は有効な G アドレス（従来の Stellar アカウント）ではありません。',
+
+  'error.fee_too_high':                '手数料 {{feeBps}} bps が最大値 {{maxBps}} bps を超えています。',
+  'error.amount_too_small':            '金額 {{amount}} が最小値 {{min}} stroops を下回っています。',
+  'error.amount_too_large':            '金額 {{amount}} が最大値 {{max}} stroops を超えています。',
+
+  'error.unsupported_exchange':        '取引所「{{exchange}}」はサポートされていません。',
+};

--- a/sdk/src/i18n/ko.ts
+++ b/sdk/src/i18n/ko.ts
@@ -1,0 +1,39 @@
+import type { MessageCatalog } from './types';
+
+/** Korean (ko) translation catalog. */
+export const ko: MessageCatalog = {
+  'error.unknown':                     '알 수 없는 오류가 발생했습니다.',
+  'error.request_failed':              '요청이 상태 코드 {{status}}(으)로 실패했습니다.',
+
+  'error.auth.unauthorized':           '인증되지 않았습니다. API 키를 확인하세요.',
+  'error.auth.forbidden':              '금지되었습니다. 이 작업을 수행할 권한이 없습니다.',
+
+  'error.validation.invalid_address':  '잘못된 주소입니다: {{address}}.',
+  'error.validation.invalid_amount':   '잘못된 금액입니다: {{amount}}. 양의 정수 문자열(stroops)이어야 합니다.',
+  'error.validation.missing_field':    '필수 필드가 없습니다: {{field}}.',
+  'error.validation.generic':          '유효성 검사 오류: {{detail}}.',
+
+  'error.not_found':                   '요청한 리소스를 찾을 수 없습니다.',
+
+  'error.rate_limit':                  '요청이 너무 많습니다. 속도를 줄여주세요.',
+  'error.rate_limit.retry_after':      '요청이 너무 많습니다. {{seconds}}초 후에 다시 시도하세요.',
+
+  'error.server':                      '서버 오류가 발생했습니다. 나중에 다시 시도하세요.',
+
+  'error.network':                     '네트워크 오류가 발생했습니다. 연결을 확인하고 다시 시도하세요.',
+  'error.timeout':                     '작업 "{{operation}}"이(가) {{ms}}ms 후에 시간 초과되었습니다.',
+
+  'error.offline.queued':              '오프라인 상태입니다. 요청이 대기열에 추가되었으며 연결이 복구되면 재시도됩니다.',
+  'error.offline.not_queued':          '오프라인 상태입니다. 요청을 대기열에 추가할 수 없습니다.',
+  'error.queue_full':                  '오프라인 대기열이 가득 찼습니다(최대 {{max}}개). 요청이 삭제되었습니다.',
+
+  'error.invalid_stellar_address':     '"{{address}}"은(는) 유효한 Stellar 주소가 아닙니다.',
+  'error.invalid_c_address':           '"{{address}}"은(는) 유효한 C-address(Soroban 스마트 계정)가 아닙니다.',
+  'error.invalid_g_address':           '"{{address}}"은(는) 유효한 G-address(기존 Stellar 계정)가 아닙니다.',
+
+  'error.fee_too_high':                '수수료 {{feeBps}} bps가 최대값 {{maxBps}} bps를 초과합니다.',
+  'error.amount_too_small':            '금액 {{amount}}이(가) 최소값 {{min}} stroops보다 작습니다.',
+  'error.amount_too_large':            '금액 {{amount}}이(가) 최대값 {{max}} stroops를 초과합니다.',
+
+  'error.unsupported_exchange':        '거래소 "{{exchange}}"은(는) 지원되지 않습니다.',
+};

--- a/sdk/src/i18n/pt.ts
+++ b/sdk/src/i18n/pt.ts
@@ -1,0 +1,39 @@
+import type { MessageCatalog } from './types';
+
+/** Portuguese (pt) translation catalog. */
+export const pt: MessageCatalog = {
+  'error.unknown':                     'Ocorreu um erro desconhecido.',
+  'error.request_failed':              'A solicitação falhou com o status {{status}}.',
+
+  'error.auth.unauthorized':           'Não autorizado. Verifique sua chave de API.',
+  'error.auth.forbidden':              'Proibido. Você não tem permissão para realizar esta ação.',
+
+  'error.validation.invalid_address':  'Endereço inválido: {{address}}.',
+  'error.validation.invalid_amount':   'Valor inválido: {{amount}}. Deve ser uma string de inteiro positivo (stroops).',
+  'error.validation.missing_field':    'Campo obrigatório ausente: {{field}}.',
+  'error.validation.generic':          'Erro de validação: {{detail}}.',
+
+  'error.not_found':                   'O recurso solicitado não foi encontrado.',
+
+  'error.rate_limit':                  'Muitas solicitações. Por favor, diminua a velocidade.',
+  'error.rate_limit.retry_after':      'Muitas solicitações. Tente novamente após {{seconds}} segundos.',
+
+  'error.server':                      'Ocorreu um erro no servidor. Tente novamente mais tarde.',
+
+  'error.network':                     'Ocorreu um erro de rede. Verifique sua conexão e tente novamente.',
+  'error.timeout':                     'A operação "{{operation}}" expirou após {{ms}} ms.',
+
+  'error.offline.queued':              'Você está offline. A solicitação foi enfileirada e será repetida quando a conectividade for restaurada.',
+  'error.offline.not_queued':          'Você está offline. Não foi possível enfileirar a solicitação.',
+  'error.queue_full':                  'A fila offline está cheia (máximo de {{max}} entradas). A solicitação foi descartada.',
+
+  'error.invalid_stellar_address':     '"{{address}}" não é um endereço Stellar válido.',
+  'error.invalid_c_address':           '"{{address}}" não é um C-address válido (conta inteligente Soroban).',
+  'error.invalid_g_address':           '"{{address}}" não é um G-address válido (conta Stellar clássica).',
+
+  'error.fee_too_high':                'A taxa de {{feeBps}} bps excede o máximo de {{maxBps}} bps.',
+  'error.amount_too_small':            'O valor {{amount}} está abaixo do mínimo de {{min}} stroops.',
+  'error.amount_too_large':            'O valor {{amount}} excede o máximo de {{max}} stroops.',
+
+  'error.unsupported_exchange':        'A exchange "{{exchange}}" não é suportada.',
+};

--- a/sdk/tests/i18n.test.ts
+++ b/sdk/tests/i18n.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SUPPORTED_LOCALES,
+  LOCALE_METADATA,
+  MESSAGE_CATALOGS,
+  en,
+} from '../src/i18n';
+import type { MessageKey, MessageCatalog } from '../src/i18n/types';
+
+/** Canonical set of message keys, derived from the baseline `en` catalog. */
+const CANONICAL_KEYS = Object.keys(en) as MessageKey[];
+
+/** Extracts `{{param}}` placeholder names from a template string. */
+function placeholdersOf(template: string): string[] {
+  const matches = template.match(/{{\s*[\w.]+\s*}}/g) ?? [];
+  return matches.map((m) => m.replace(/[{}]/g, '').trim()).sort();
+}
+
+describe('i18n: SUPPORTED_LOCALES / LOCALE_METADATA', () => {
+  it('has metadata for every supported locale', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(LOCALE_METADATA[locale]).toBeDefined();
+      expect(LOCALE_METADATA[locale].nativeName).toBeTruthy();
+      expect(LOCALE_METADATA[locale].language).toBeTruthy();
+      expect(['ltr', 'rtl']).toContain(LOCALE_METADATA[locale].dir);
+    }
+  });
+
+  it('has no metadata entries for unsupported locales', () => {
+    expect(Object.keys(LOCALE_METADATA).sort()).toEqual([...SUPPORTED_LOCALES].sort());
+  });
+});
+
+describe('i18n: MESSAGE_CATALOGS registry', () => {
+  it('has a catalog for every supported locale', () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(MESSAGE_CATALOGS[locale]).toBeDefined();
+    }
+  });
+
+  it('has no catalogs for unsupported locales', () => {
+    expect(Object.keys(MESSAGE_CATALOGS).sort()).toEqual([...SUPPORTED_LOCALES].sort());
+  });
+});
+
+describe.each(SUPPORTED_LOCALES)('i18n catalog: %s', (locale) => {
+  const catalog: MessageCatalog = MESSAGE_CATALOGS[locale];
+
+  it('defines every MessageKey with no missing keys', () => {
+    const missing = CANONICAL_KEYS.filter((key) => !(key in catalog));
+    expect(missing).toEqual([]);
+  });
+
+  it('defines no keys beyond MessageKey', () => {
+    const extra = Object.keys(catalog).filter((key) => !CANONICAL_KEYS.includes(key as MessageKey));
+    expect(extra).toEqual([]);
+  });
+
+  it('has exactly the canonical key count', () => {
+    expect(Object.keys(catalog)).toHaveLength(CANONICAL_KEYS.length);
+  });
+
+  it('maps every key to a non-empty string', () => {
+    for (const key of CANONICAL_KEYS) {
+      expect(typeof catalog[key]).toBe('string');
+      expect(catalog[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('preserves the same {{param}} placeholders as the en baseline', () => {
+    for (const key of CANONICAL_KEYS) {
+      expect(placeholdersOf(catalog[key])).toEqual(placeholdersOf(en[key]));
+    }
+  });
+});
+
+describe('i18n: en baseline sanity', () => {
+  it('covers every declared MessageKey (canonical source of truth)', () => {
+    expect(CANONICAL_KEYS.length).toBeGreaterThan(0);
+    expect(new Set(CANONICAL_KEYS).size).toBe(CANONICAL_KEYS.length);
+  });
+});


### PR DESCRIPTION
- Add missing ja/ko/fr/pt i18n catalogs and an i18n/index.ts registry; add tests validating every locale catalog against MessageKey for completeness and preserved {{param}} placeholders (#273)
- Add a single-file UMD/IIFE esbuild bundle (dist/bridge.umd.js, window.BridgeSDK) so sdk/examples/browser.html actually works (#274)
- Rewrite wallet-integration.md's Error Handling section to reflect the typed BridgeError hierarchy and isXError guards (#275)
- Add a BridgeClient quickstart to sdk/README.md and complete the fixtures reference table (#276)
- Ignore test snapshot/build-cache artifacts in .gitignore
Closes #273 
Closes #274 
Closes #275 
Closes #276 


### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
