### PR TITLE
Fix CEX withdrawal stubs and MoonPay quote drift (#277, #278, #279, #280)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage/
 !.vscode/settings.json
 !.vscode/extensions.json
 test_snapshots/
+__snapshots__/
+*.snap
+.tmp/
 deployments/*.json
 .secrets.local.json
 .secrets.local.enc

--- a/api/src/openapi/spec.ts
+++ b/api/src/openapi/spec.ts
@@ -242,6 +242,28 @@ const WidgetUrlResponse = registry.register(
   z.object({ url: z.string().url() }).openapi({ title: 'WidgetUrlResponse' }),
 );
 
+const MoonpayQuoteQuery = registry.register(
+  'MoonpayQuoteQuery',
+  z
+    .object({
+      baseCurrency: z.string().openapi({ example: 'USD' }),
+      baseCurrencyAmount: z.coerce.number().positive().openapi({ example: 100 }),
+      quoteCurrency: z.string().default('xlm').openapi({ example: 'xlm' }),
+    })
+    .openapi({ title: 'MoonpayQuoteQuery' }),
+);
+
+const MoonpayQuoteResponse = registry.register(
+  'MoonpayQuoteResponse',
+  z
+    .object({
+      quoteCurrencyAmount: z.number(),
+      feeAmount: z.number(),
+      totalAmount: z.number(),
+    })
+    .openapi({ title: 'MoonpayQuoteResponse' }),
+);
+
 registry.registerPath({
   method: 'post',
   path: '/api/v2/offramp/moonpay',
@@ -253,6 +275,22 @@ registry.registerPath({
   request: { body: { content: { 'application/json': { schema: MoonpayOfframpRequest } } } },
   responses: {
     200: { description: 'Widget URL', content: { 'application/json': { schema: WidgetUrlResponse } } },
+    400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
+    401: { description: 'Missing or invalid API key', content: { 'application/json': { schema: ErrorResponse } } },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: '/api/v2/offramp/moonpay/quote',
+  operationId: 'moonpayBuyQuote',
+  summary: 'Fetch a real-time MoonPay buy quote',
+  description: 'Returns quote, fee, and total amounts for converting a fiat base currency to a crypto quote currency via MoonPay.',
+  tags: ['Offramp'],
+  security: [{ ApiKeyAuth: ['offramp:write'] }],
+  request: { query: MoonpayQuoteQuery },
+  responses: {
+    200: { description: 'Buy quote', content: { 'application/json': { schema: MoonpayQuoteResponse } } },
     400: { description: 'Validation error', content: { 'application/json': { schema: ErrorResponse } } },
     401: { description: 'Missing or invalid API key', content: { 'application/json': { schema: ErrorResponse } } },
   },

--- a/api/src/routes/offramp.ts
+++ b/api/src/routes/offramp.ts
@@ -18,6 +18,12 @@ const moonpaySchema = z.object({
   email: z.string().email().optional(),
 });
 
+const moonpayQuoteSchema = z.object({
+  baseCurrency: z.string().min(1),
+  baseCurrencyAmount: z.coerce.number().positive(),
+  quoteCurrency: z.string().min(1).default('xlm'),
+});
+
 const transakSchema = z.object({
   walletAddress: z.string().regex(STELLAR_ADDRESS_REGEX, 'invalid Stellar address'),
   network: z.string().default('stellar'),
@@ -45,6 +51,16 @@ offrampRouter.post('/moonpay', async (req: Request, res: Response, next: NextFun
       { provider: 'moonpay', status: 'failed' },
       () => onrampRequestCount.inc({ provider: 'moonpay', status: 'failed' }),
     );
+    next(err);
+  }
+});
+
+offrampRouter.get('/moonpay/quote', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const params = moonpayQuoteSchema.parse(req.query);
+    const quote = await moonpayService.getBuyQuote(params);
+    res.json(quote);
+  } catch (err) {
     next(err);
   }
 });

--- a/api/src/services/moonpay.ts
+++ b/api/src/services/moonpay.ts
@@ -47,6 +47,55 @@ export class MoonpayService {
     const baseUrl = 'https://buy.moonpay.com';
     return `${baseUrl}?${queryParams.toString()}`;
   }
+
+  /**
+   * Fetches a real-time buy quote from the MoonPay API.
+   *
+   * @param params - Base currency, amount, and quote currency.
+   * @returns Quote amounts and fees from MoonPay.
+   * @throws {Error} If the request times out, MoonPay returns a non-2xx response,
+   * or the response is missing expected numeric fields.
+   */
+  async getBuyQuote(params: {
+    baseCurrency: string;
+    baseCurrencyAmount: number;
+    quoteCurrency: string;
+  }): Promise<{
+    quoteCurrencyAmount: number;
+    feeAmount: number;
+    totalAmount: number;
+  }> {
+    const url = `https://api.moonpay.com/v3/currencies/${params.quoteCurrency}/buy_quote`;
+    const query = new URLSearchParams({
+      apiKey: this.apiKey,
+      baseCurrencyAmount: params.baseCurrencyAmount.toString(),
+      baseCurrency: params.baseCurrency,
+      areFeesIncluded: 'true',
+    });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+    let res: Response;
+    try {
+      res = await fetch(`${url}?${query.toString()}`, { signal: controller.signal });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!res.ok) throw new Error(`moonpay quote failed: ${res.statusText}`);
+
+    const data = await res.json();
+    const { quoteCurrencyAmount, feeAmount, totalAmount } = data ?? {};
+    if (
+      typeof quoteCurrencyAmount !== 'number'
+      || typeof feeAmount !== 'number'
+      || typeof totalAmount !== 'number'
+    ) {
+      throw new Error('moonpay quote response missing expected numeric fields');
+    }
+
+    return { quoteCurrencyAmount, feeAmount, totalAmount };
+  }
 }
 
 export const moonpayService = new MoonpayService();

--- a/cex/withdrawal-router.ts
+++ b/cex/withdrawal-router.ts
@@ -1,9 +1,13 @@
+import crypto from 'crypto';
+
 /** Configuration for a registered exchange integration. */
 export interface CexConfig {
   name: string;
   apiBaseUrl: string;
   apiKey?: string;
   apiSecret?: string;
+  /** Required by exchanges (e.g. Coinbase) that use a passphrase-protected API key. */
+  apiPassphrase?: string;
 }
 
 /** Withdrawal request to be routed to an exchange. */
@@ -110,38 +114,151 @@ export function parseCexWithdrawalMemo(memo: string): {
   return {};
 }
 
+/** POSTs to an exchange endpoint, aborting after 15s so a hung exchange API can't hang the caller. */
+async function postToExchange(
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+
+  try {
+    return await fetch(url, { method: 'POST', headers, body, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 /**
- * Stub handlers for Binance, Coinbase, and Kraken.
- * These return placeholder responses and do not make real API calls.
- *
- * TODO: replace each stub with a real implementation that calls the exchange's
- * withdrawal API using credentials from `config.apiKey` / `config.apiSecret`.
+ * Default handlers for Binance, Coinbase, and Kraken.
+ * Each calls the exchange's withdrawal API using credentials from `config`, signed per that
+ * exchange's auth scheme, and returns `success: false` / `status: 'failed'` if the call fails
+ * or times out rather than reporting a fake success.
  */
 export const defaultCexHandlers: Record<string, WithdrawalHandler> = {
-  async binance(_req, _config) {
-    return {
-      success: true,
-      withdrawalId: `bin-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      status: 'pending',
-      estimatedCompletion: '5-30 minutes',
-    };
+  async binance(req, config) {
+    try {
+      const params: Record<string, string> = {
+        coin: req.asset,
+        amount: req.amount,
+        address: req.destinationAddress,
+        network: req.network,
+        timestamp: String(Date.now()),
+        recvWindow: '5000',
+      };
+      if (req.destinationTag) params.addressTag = req.destinationTag;
+
+      const query = new URLSearchParams(params).toString();
+      const signature = crypto.createHmac('sha256', config.apiSecret ?? '').update(query).digest('hex');
+
+      const res = await postToExchange(
+        `${config.apiBaseUrl}/sapi/v1/capital/withdraw/apply?${query}&signature=${signature}`,
+        { 'X-MBX-APIKEY': config.apiKey ?? '', 'Content-Type': 'application/x-www-form-urlencoded' },
+        '',
+      );
+
+      if (!res.ok) {
+        console.error(`binance withdrawal failed: ${res.status} ${await res.text()}`);
+        return { success: false, withdrawalId: `bin-${Date.now()}`, status: 'failed' };
+      }
+
+      const data = await res.json() as { id?: string; txId?: string };
+      return {
+        success: true,
+        withdrawalId: `bin-${data.id ?? Date.now()}`,
+        txHash: data.txId,
+        status: 'pending',
+        estimatedCompletion: '5-30 minutes',
+      };
+    } catch (err) {
+      console.error('binance API error:', err);
+      return { success: false, withdrawalId: `bin-${Date.now()}`, status: 'failed' };
+    }
   },
 
-  async coinbase(_req, _config) {
-    return {
-      success: true,
-      withdrawalId: `cb-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      status: 'pending',
-      estimatedCompletion: '5-30 minutes',
-    };
+  async coinbase(req, config) {
+    const requestPath = '/v2/accounts/withdrawals';
+    try {
+      const body = JSON.stringify({
+        type: 'send',
+        to: req.destinationAddress,
+        amount: req.amount,
+        currency: req.asset,
+        description: req.destinationTag,
+      });
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const prehash = `${timestamp}POST${requestPath}${body}`;
+      const signature = crypto
+        .createHmac('sha256', Buffer.from(config.apiSecret ?? '', 'base64'))
+        .update(prehash)
+        .digest('base64');
+
+      const res = await postToExchange(`${config.apiBaseUrl}${requestPath}`, {
+        'Content-Type': 'application/json',
+        'CB-ACCESS-KEY': config.apiKey ?? '',
+        'CB-ACCESS-SIGN': signature,
+        'CB-ACCESS-TIMESTAMP': timestamp,
+        'CB-ACCESS-PASSPHRASE': config.apiPassphrase ?? '',
+      }, body);
+
+      if (!res.ok) {
+        console.error(`coinbase withdrawal failed: ${res.status} ${await res.text()}`);
+        return { success: false, withdrawalId: `cb-${Date.now()}`, status: 'failed' };
+      }
+
+      const data = await res.json() as { data?: { id?: string } };
+      return {
+        success: true,
+        withdrawalId: `cb-${data.data?.id ?? Date.now()}`,
+        status: 'pending',
+        estimatedCompletion: '5-30 minutes',
+      };
+    } catch (err) {
+      console.error('coinbase API error:', err);
+      return { success: false, withdrawalId: `cb-${Date.now()}`, status: 'failed' };
+    }
   },
 
-  async kraken(_req, _config) {
-    return {
-      success: true,
-      withdrawalId: `kr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-      status: 'pending',
-      estimatedCompletion: '5-30 minutes',
-    };
+  async kraken(req, config) {
+    const path = '/0/private/Withdraw';
+    try {
+      const nonce = String(Date.now());
+      const body = new URLSearchParams({
+        asset: req.asset,
+        key: req.destinationAddress,
+        amount: req.amount,
+        nonce,
+      }).toString();
+
+      const sha256Hash = crypto.createHash('sha256').update(nonce + body).digest();
+      const message = Buffer.concat([Buffer.from(path), sha256Hash]);
+      const signature = crypto
+        .createHmac('sha512', Buffer.from(config.apiSecret ?? '', 'base64'))
+        .update(message)
+        .digest('base64');
+
+      const res = await postToExchange(`${config.apiBaseUrl}${path}`, {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'API-Key': config.apiKey ?? '',
+        'API-Sign': signature,
+      }, body);
+
+      if (!res.ok) {
+        console.error(`kraken withdrawal failed: ${res.status} ${await res.text()}`);
+        return { success: false, withdrawalId: `kr-${Date.now()}`, status: 'failed' };
+      }
+
+      const data = await res.json() as { result?: { refid?: string } };
+      return {
+        success: true,
+        withdrawalId: `kr-${data.result?.refid ?? Date.now()}`,
+        status: 'pending',
+        estimatedCompletion: '5-30 minutes',
+      };
+    } catch (err) {
+      console.error('kraken API error:', err);
+      return { success: false, withdrawalId: `kr-${Date.now()}`, status: 'failed' };
+    }
   },
 };

--- a/offramp/moonpay.ts
+++ b/offramp/moonpay.ts
@@ -9,6 +9,7 @@ export interface MoonpayConfig {
 /** Parameters for building a MoonPay widget URL. */
 export interface MoonpayPurchaseParams {
   walletAddress: string;
+  walletNetwork: string;
   currencyCode?: string;
   baseCurrency?: string;
   baseCurrencyAmount?: number;
@@ -27,6 +28,7 @@ export function createMoonpayWidgetUrl(config: MoonpayConfig, params: MoonpayPur
   const query = new URLSearchParams({
     apiKey: config.apiKey,
     walletAddress: params.walletAddress,
+    walletNetwork: params.walletNetwork,
     currencyCode: params.currencyCode ?? 'xlm',
   });
 
@@ -80,12 +82,27 @@ export async function getMoonpayBuyQuote(config: MoonpayConfig, params: {
     baseCurrency: params.baseCurrency,
     areFeesIncluded: 'true',
   });
-  const res = await fetch(`${url}?${query.toString()}`);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+  let res: Response;
+  try {
+    res = await fetch(`${url}?${query.toString()}`, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+
   if (!res.ok) throw new Error(`moonpay quote failed: ${res.statusText}`);
+
   const data = await res.json();
-  return {
-    quoteCurrencyAmount: data.quoteCurrencyAmount,
-    feeAmount: data.feeAmount,
-    totalAmount: data.totalAmount,
-  };
+  const { quoteCurrencyAmount, feeAmount, totalAmount } = data ?? {};
+  if (
+    typeof quoteCurrencyAmount !== 'number'
+    || typeof feeAmount !== 'number'
+    || typeof totalAmount !== 'number'
+  ) {
+    throw new Error('moonpay quote response missing expected numeric fields');
+  }
+
+  return { quoteCurrencyAmount, feeAmount, totalAmount };
 }


### PR DESCRIPTION
- Replace fake-success default CEX handlers (binance/coinbase/kraken) in cex/withdrawal-router.ts with real signed, timeout-guarded requests
- Add missing walletNetwork param to the standalone MoonPay widget builder
- Add request timeout and response-shape validation to getMoonpayBuyQuote
- Wire a real buy-quote endpoint into the API (GET /offramp/moonpay/quote)
- Ignore additional test-artifact patterns in .gitignore
Closes #277 
Closes #278 
Closes #279 
Closes #280 

## Testing

<!-- How was this tested? Which test commands were run? -->

- [ ] `cargo test` (contract changes)
- [ ] `npm run test --workspaces`
- [ ] `npm run build` passes without errors
- [ ] Manual testing (describe below if applicable)

```
# paste relevant test output here if it adds context
```

---

## Code Review Checklist

### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
