### PR TITLE
fix: resolve issues #285, #286, #287, #288

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,76 +14,27 @@ on:
 
 jobs:
   examples:
-    name: Examples (${{ matrix.lang }})
+    name: Verify all language examples
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        lang: [python, rust, go, java]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Start mock server
-        run: |
-          node examples/mock-server/server.mjs &
-          echo "MOCK_PID=$!" >> "$GITHUB_ENV"
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:3099/health && break
-            sleep 0.5
-          done
-
-      - name: Python example
-        if: matrix.lang == 'python'
-        env:
-          BRIDGE_BASE_URL: http://localhost:3099
-        run: |
-          cd examples/python
-          python3 main.py
-
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        if: matrix.lang == 'rust'
         with:
           toolchain: stable
 
-      - name: Rust example
-        if: matrix.lang == 'rust'
-        env:
-          BRIDGE_BASE_URL: http://localhost:3099
-        run: |
-          cd examples/rust
-          cargo run --example bridge
-
       - uses: actions/setup-go@v5
-        if: matrix.lang == 'go'
         with:
           go-version: '1.22'
 
-      - name: Go example
-        if: matrix.lang == 'go'
-        env:
-          BRIDGE_BASE_URL: http://localhost:3099
-        run: |
-          cd examples/go
-          go run .
-
       - uses: actions/setup-java@v4
-        if: matrix.lang == 'java'
         with:
           distribution: temurin
           java-version: '17'
 
-      - name: Java example
-        if: matrix.lang == 'java'
-        env:
-          BRIDGE_BASE_URL: http://localhost:3099
-        run: |
-          cd examples/java
-          mvn -q compile exec:java
-
-      - name: Stop mock server
-        if: always()
-        run: kill "$MOCK_PID" 2>/dev/null || true
+      - name: Run all language examples via verify-examples.sh
+        run: bash examples/scripts/verify-examples.sh
 
   docker-compose:
     name: Docker Compose Examples

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,32 @@ logs/secrets-audit.jsonl
 # Python bytecode
 __pycache__/
 *.pyc
+*.pyo
+*.pyd
+
+# Rust build artifacts
+examples/rust/target/
+contracts/onboarding-bridge/target/
+contracts/onboarding-bridge/fuzz/target/
+*.lock.bak
+
+# Java / Maven build artifacts
+examples/java/target/
+
+# Test output / snapshots
+*.snap
+**/__snapshots__/
+vitest-results/
+junit-*.xml
+test-results/
+
+# OS / editor artefacts
+*.swp
+*.swo
+*~
+.editorconfig.bak
+
+# Temporary files
+*.tmp
+*.bak
+.nyc_output/

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Runnable integration examples for the C-Address Bridge API in **Python**, **Rust
 | Transaction status | `GET /api/v1/status/:hash` |
 | MoonPay URL | `POST /api/v1/offramp/moonpay` |
 | Transak URL | `POST /api/v1/offramp/transak` |
+| CEX withdrawal routing | `POST /api/v1/cex/route` |
 | Error handling | Typed errors per language |
 
 Examples run against a lightweight mock server by default — no live API or secrets required.

--- a/examples/go/caddressbridge/client.go
+++ b/examples/go/caddressbridge/client.go
@@ -129,3 +129,7 @@ func (c *BridgeClient) CreateMoonpayURL(body map[string]any) (map[string]any, er
 func (c *BridgeClient) CreateTransakURL(body map[string]any) (map[string]any, error) {
 	return c.request(http.MethodPost, "/api/v1/offramp/transak", nil, body)
 }
+
+func (c *BridgeClient) RouteCexWithdrawal(body map[string]any) (map[string]any, error) {
+	return c.request(http.MethodPost, "/api/v1/cex/route", nil, body)
+}

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -49,7 +49,11 @@ func run(client *caddressbridge.BridgeClient) error {
 	}
 	fmt.Printf("Fund submitted: %v hash=%v\n", funded["status"], funded["hash"])
 
-	status, err := client.GetStatus(funded["hash"].(string))
+	hash, ok := funded["hash"].(string)
+	if !ok || hash == "" {
+		return fmt.Errorf("fund response missing or invalid hash field")
+	}
+	status, err := client.GetStatus(hash)
 	if err != nil {
 		return err
 	}
@@ -78,5 +82,17 @@ func run(client *caddressbridge.BridgeClient) error {
 		return err
 	}
 	fmt.Printf("Transak URL: %v\n", transak["url"])
+
+	cex, err := client.RouteCexWithdrawal(map[string]any{
+		"exchange":      "coinbase",
+		"sourceAsset":   "XLM",
+		"amount":        "10000000",
+		"targetCAddress": mockCAddress,
+		"targetNetwork": "stellar",
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("CEX withdrawal: status=%v id=%v\n", cex["status"], cex["withdrawalId"])
 	return nil
 }

--- a/examples/java/src/main/java/com/caddressbridge/BridgeClient.java
+++ b/examples/java/src/main/java/com/caddressbridge/BridgeClient.java
@@ -96,4 +96,8 @@ public final class BridgeClient {
     public String createTransakUrl(String jsonBody) throws IOException, InterruptedException, BridgeException {
         return request("POST", "/api/v1/offramp/transak", null, jsonBody);
     }
+
+    public String routeCexWithdrawal(String jsonBody) throws IOException, InterruptedException, BridgeException {
+        return request("POST", "/api/v1/cex/route", null, jsonBody);
+    }
 }

--- a/examples/java/src/main/java/com/caddressbridge/example/Example.java
+++ b/examples/java/src/main/java/com/caddressbridge/example/Example.java
@@ -31,6 +31,10 @@ public final class Example {
                     "{\"walletAddress\":\"%s\",\"network\":\"stellar\",\"fiatCurrency\":\"USD\","
                             + "\"cryptoCurrency\":\"XLM\",\"fiatAmount\":100}",
                     MOCK_C_ADDRESS)));
+            System.out.println("CEX: " + client.routeCexWithdrawal(String.format(
+                    "{\"exchange\":\"coinbase\",\"sourceAsset\":\"XLM\",\"amount\":\"10000000\","
+                            + "\"targetCAddress\":\"%s\",\"targetNetwork\":\"stellar\"}",
+                    MOCK_C_ADDRESS)));
             System.out.println("All flows completed successfully.");
         } catch (BridgeException e) {
             System.err.printf("Bridge error (%d): %s%n", e.getStatusCode(), e.getMessage());

--- a/examples/mock-server/server.mjs
+++ b/examples/mock-server/server.mjs
@@ -71,6 +71,9 @@ function send(res, status, body) {
 
 function route(method, pathname) {
   if (method === 'GET' && pathname === '/health') return { status: 200, body: { status: 'ok' } };
+  if (method === 'GET' && pathname === '/api/v1/quote' && process.env.MOCK_FORCE_ERROR === '1') {
+    return { status: 503, body: { message: 'Service unavailable', code: 'SERVICE_UNAVAILABLE' } };
+  }
   if (method === 'GET' && pathname === '/api/v1/quote') return { status: 200, body: fixtures.quote };
   if (method === 'POST' && pathname === '/api/v1/fund/prepare') return { status: 200, body: fixtures.fundingPrepare };
   if (method === 'POST' && pathname === '/api/v1/fund') return { status: 201, body: fixtures.fundingResult };
@@ -78,9 +81,7 @@ function route(method, pathname) {
   if (method === 'POST' && pathname === '/api/v1/offramp/moonpay') return { status: 200, body: fixtures.moonpay };
   if (method === 'POST' && pathname === '/api/v1/offramp/transak') return { status: 200, body: fixtures.transak };
   if (method === 'POST' && pathname === '/api/v1/cex/route') return { status: 200, body: fixtures.cex };
-  if (method === 'GET' && pathname === '/api/v1/quote' && process.env.MOCK_FORCE_ERROR === '1') {
-    return { status: 503, body: { message: 'Service unavailable', code: 'SERVICE_UNAVAILABLE' } };
-  }
+
   return { status: 404, body: { message: `No mock for ${method} ${pathname}` } };
 }
 

--- a/examples/python/c_address_bridge/client.py
+++ b/examples/python/c_address_bridge/client.py
@@ -97,5 +97,8 @@ class BridgeClient:
     def create_transak_url(self, **params: Any) -> dict[str, str]:
         return self._request("POST", "/api/v1/offramp/transak", body=params)
 
+    def route_cex_withdrawal(self, **params: Any) -> dict[str, Any]:
+        return self._request("POST", "/api/v1/cex/route", body=params)
+
     def health(self) -> dict[str, str]:
         return self._request("GET", "/health")

--- a/examples/python/main.py
+++ b/examples/python/main.py
@@ -53,6 +53,15 @@ def main() -> int:
         )
         print(f"Transak URL: {transak['url'][:60]}...")
 
+        cex = client.route_cex_withdrawal(
+            exchange="coinbase",
+            sourceAsset="XLM",
+            amount="10000000",
+            targetCAddress=MOCK_C_ADDRESS,
+            targetNetwork="stellar",
+        )
+        print(f"CEX withdrawal: status={cex['status']} id={cex['withdrawalId']}")
+
         print("All flows completed successfully.")
         return 0
     except BridgeError as exc:

--- a/examples/rust/examples/bridge.rs
+++ b/examples/rust/examples/bridge.rs
@@ -61,6 +61,17 @@ async fn main() -> Result<(), BridgeError> {
         .await?;
     println!("Transak URL: {}...", &transak.url[..transak.url.len().min(60)]);
 
+    let cex = client
+        .route_cex_withdrawal(json!({
+            "exchange": "coinbase",
+            "sourceAsset": "XLM",
+            "amount": "10000000",
+            "targetCAddress": MOCK_C_ADDRESS,
+            "targetNetwork": "stellar"
+        }))
+        .await?;
+    println!("CEX withdrawal: status={} id={}", cex.status, cex.withdrawal_id);
+
     println!("All flows completed successfully.");
     Ok(())
 }

--- a/examples/rust/src/client.rs
+++ b/examples/rust/src/client.rs
@@ -1,6 +1,6 @@
 use crate::error::BridgeError;
 use crate::types::{
-    FundPrepareBody, FundPrepareResult, FundingResult, Quote, TransactionStatus, WidgetUrl,
+    CexResult, FundPrepareBody, FundPrepareResult, FundingResult, Quote, TransactionStatus, WidgetUrl,
 };
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, CONTENT_TYPE};
 use serde_json::{json, Value};
@@ -133,6 +133,13 @@ impl BridgeClient {
     pub async fn create_transak_url(&self, body: Value) -> Result<WidgetUrl, BridgeError> {
         let value = self
             .request(reqwest::Method::POST, "/api/v1/offramp/transak", &[], Some(body))
+            .await?;
+        Ok(serde_json::from_value(value)?)
+    }
+
+    pub async fn route_cex_withdrawal(&self, body: Value) -> Result<CexResult, BridgeError> {
+        let value = self
+            .request(reqwest::Method::POST, "/api/v1/cex/route", &[], Some(body))
             .await?;
         Ok(serde_json::from_value(value)?)
     }

--- a/examples/rust/src/types.rs
+++ b/examples/rust/src/types.rs
@@ -46,3 +46,13 @@ pub struct FundPrepareResult {
     pub instruction: String,
     pub simulation: HashMap<String, String>,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct CexResult {
+    pub status: String,
+    #[serde(rename = "withdrawalId")]
+    pub withdrawal_id: String,
+    #[serde(rename = "estimatedArrival")]
+    pub estimated_arrival: String,
+    pub fee: String,
+}


### PR DESCRIPTION
#285 — Wire verify-examples.sh into examples.yml CI workflow. Replace per-language matrix steps that duplicated the script's logic with a single job that calls examples/scripts/verify-examples.sh directly, keeping CI and the script in sync.

#286 — Fix MOCK_FORCE_ERROR dead code in mock server. The MOCK_FORCE_ERROR check was placed after the unconditional quote success return, making it unreachable. Moved the error-simulation branch before the success return so MOCK_FORCE_ERROR=1 can actually trigger a 503, enabling error-handling paths in all language clients to be exercised.

#287 — Add CEX withdrawal routing to all four language clients. Implemented route_cex_withdrawal / RouteCexWithdrawal / routeCexWithdrawal in Python, Go, Rust, and Java clients. Added corresponding calls in each language's main/example entrypoint. Added CexResult type to Rust types.rs. Updated examples/README.md flow table to include the CEX withdrawal routing endpoint.

#288 — Fix unchecked type assertion in Go main.go. Replaced funded["hash"].(string) with the safe two-value form hash, ok := funded["hash"].(string), returning a descriptive error instead of panicking when the field is absent or not a string.

Also update .gitignore to exclude test snapshots, Rust/Java build artifacts, vitest results, and common OS/editor noise files.
Closes #285 
Closes #286 
Closes #287 
Closes #288 

## Testing

<!-- How was this tested? Which test commands were run? -->

- [ ] `cargo test` (contract changes)
- [ ] `npm run test --workspaces`
- [ ] `npm run build` passes without errors
- [ ] Manual testing (describe below if applicable)

```
# paste relevant test output here if it adds context
```

---

## Code Review Checklist

### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
