### PR TITLE
fix(sdk): resolve cache eviction, telemetry queue, and offline retry …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,30 @@ logs/secrets-audit.jsonl
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Vitest / Jest snapshots and cache
+**/__snapshots__/
+**/.vitest-cache/
+**/.jest-cache/
+.vitest/
+
+# TypeScript build info
+*.tsbuildinfo
+
+# npm / yarn / pnpm lockfile artifacts (keep package-lock.json but ignore temp files)
+.npmrc.local
+.yarnrc.local
+
+# OS-generated files
+ehthumbs.db
+desktop.ini
+
+# Editor swap / backup files
+*.swp
+*.swo
+*~
+
+# Test output artifacts
+junit.xml
+test-results/
+

--- a/sdk/src/cache.ts
+++ b/sdk/src/cache.ts
@@ -42,7 +42,9 @@ export class SimpleCache {
   }
 
   set<T>(key: string, value: T, ttlMs: number, staleWhileRevalidate = false): void {
-    if (this.entries.size >= this.maxEntries) {
+    // Only evict when the key is genuinely new (i.e. the map would actually grow).
+    // Updating an existing key never changes the map size, so no eviction is needed.
+    if (!this.entries.has(key) && this.entries.size >= this.maxEntries) {
       const oldestKey = this.entries.keys().next().value;
       if (oldestKey) {
         this.entries.delete(oldestKey);

--- a/sdk/src/offline.ts
+++ b/sdk/src/offline.ts
@@ -1,14 +1,36 @@
 import { QueueEntry, OfflineQueueOptions, StorageAdapter, RequestOptions, HttpMethod } from './types';
 import { BridgeClient, BridgeClientConfig } from './bridge';
-import { OfflineError, QueueFullError, TimeoutError } from './errors';
+import { BridgeError, OfflineError, QueueFullError, TimeoutError } from './errors';
 
 const QUEUE_STORAGE_KEY = 'bridge_sdk_offline_queue';
 
+/** Default maximum number of replay attempts before an entry is dropped. */
+const DEFAULT_MAX_RETRY_COUNT = 3;
+
 type DrainHandler = (count: number, at: string) => void;
+
+/** Classifies whether a caught error should be retried on the next health-check. */
+function isRetryableQueueError(err: unknown): boolean {
+  // BridgeErrors carry an explicit retryable flag — honour it.
+  if (err instanceof BridgeError) return err.retryable;
+  // Generic network-level errors (TypeError from fetch) are retryable.
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    return (
+      msg.includes('failed to fetch') ||
+      msg.includes('network') ||
+      msg.includes('econnrefused') ||
+      msg.includes('enotfound')
+    );
+  }
+  return false;
+}
 
 export class OfflineQueue {
   private queue: QueueEntry[] = [];
   private readonly maxSize: number;
+  private readonly maxRetryCount: number;
   private readonly storage?: StorageAdapter;
   private healthTimer?: ReturnType<typeof setInterval>;
   private serverOnline = true;
@@ -21,6 +43,7 @@ export class OfflineQueue {
     options?: OfflineQueueOptions,
   ) {
     this.maxSize = options?.maxSize ?? 50;
+    this.maxRetryCount = options?.maxRetryCount ?? DEFAULT_MAX_RETRY_COUNT;
     this.storage = options?.storageAdapter;
     const intervalMs = options?.healthCheckIntervalMs ?? 5_000;
 
@@ -90,8 +113,21 @@ export class OfflineQueue {
       try {
         await this.executeEntry(entry);
         processedCount++;
-      } catch {
+      } catch (err) {
+        // Non-retryable errors (e.g. 400 Validation, 401 Auth) are dropped
+        // immediately — retrying them will never succeed.
+        if (!isRetryableQueueError(err)) {
+          continue;
+        }
+
         entry.retryCount++;
+
+        // Drop entries that have exceeded the maximum retry count so they
+        // don't pile up and retry forever on every health-check cycle.
+        if (entry.retryCount > this.maxRetryCount) {
+          continue;
+        }
+
         remaining.push(entry);
       }
     }

--- a/sdk/src/telemetry.ts
+++ b/sdk/src/telemetry.ts
@@ -29,16 +29,27 @@ export class FetchTelemetryTransport implements TelemetryTransport {
   }
 }
 
+/** Maximum number of events held in the in-memory queue when no flush can occur. */
+const MAX_QUEUE_SIZE = 100;
+
 export class TelemetryClient {
   private readonly transport: TelemetryTransport;
   private readonly enabled: boolean;
   private readonly flushIntervalMs: number;
   private readonly queue: TelemetryEvent[] = [];
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** True when a real endpoint is configured and flush is scheduled. */
+  private readonly hasEndpoint: boolean;
 
   constructor(options: { endpoint?: string; enabled?: boolean; intervalMs?: number; transport?: TelemetryTransport } = {}) {
     const runtimeProcess = typeof process !== 'undefined' ? process : undefined;
-    this.enabled = options.enabled ?? (runtimeProcess?.env?.SDK_TELEMETRY_ENABLED !== 'false');
+    this.hasEndpoint = Boolean(options.endpoint || options.transport);
+    // Default enabled to false when no endpoint is configured to prevent the
+    // queue from growing unboundedly with no flush ever triggered (#258).
+    const defaultEnabled = this.hasEndpoint
+      ? runtimeProcess?.env?.SDK_TELEMETRY_ENABLED !== 'false'
+      : false;
+    this.enabled = options.enabled ?? defaultEnabled;
     this.flushIntervalMs = options.intervalMs ?? 60_000;
     this.transport = options.transport ?? (options.endpoint ? new FetchTelemetryTransport(options.endpoint) : new NoopTelemetryTransport());
 
@@ -52,6 +63,12 @@ export class TelemetryClient {
       return;
     }
 
+    // Safety cap: if the queue is full (e.g. flush is lagging) drop the oldest
+    // entry so memory usage stays bounded regardless of flush frequency.
+    if (this.queue.length >= MAX_QUEUE_SIZE) {
+      this.queue.shift();
+    }
+
     const runtimeProcess = typeof process !== 'undefined' ? process : undefined;
     this.queue.push({
       sdkVersion: runtimeProcess?.env?.npm_package_version || '0.1.0',
@@ -59,6 +76,21 @@ export class TelemetryClient {
       platform: runtimeProcess?.platform || 'unknown',
       ...event,
     });
+  }
+
+  /** Returns the number of events currently held in the queue. */
+  getQueueSize(): number {
+    return this.queue.length;
+  }
+
+  /** Manually flush all queued events through the transport. */
+  flush(): void {
+    if (this.queue.length === 0) {
+      return;
+    }
+
+    const batch = this.queue.splice(0, this.queue.length);
+    batch.forEach((event) => this.transport.send(event));
   }
 
   private start(): void {
@@ -73,14 +105,5 @@ export class TelemetryClient {
     if (this.timer.unref) {
       this.timer.unref();
     }
-  }
-
-  private flush(): void {
-    if (this.queue.length === 0) {
-      return;
-    }
-
-    const batch = this.queue.splice(0, this.queue.length);
-    batch.forEach((event) => this.transport.send(event));
   }
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -224,6 +224,8 @@ export interface QueueEntry {
 
 export interface OfflineQueueOptions {
   maxSize?: number;
+  /** Maximum number of replay attempts before an entry is dropped. Default: 3. */
+  maxRetryCount?: number;
   storageAdapter?: StorageAdapter;
   healthCheckIntervalMs?: number;
   autoQueue?: boolean;

--- a/sdk/tests/cache-telemetry-offline.test.ts
+++ b/sdk/tests/cache-telemetry-offline.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for issues #257, #258, #259, #260
+ *
+ * #257 – SimpleCache: updating an existing key at capacity must not evict other entries
+ * #258 – TelemetryClient: queue must not grow unboundedly when no endpoint is set
+ * #259 – TelemetryClient: queueing, flush, and both transport implementations
+ * #260 – OfflineQueue: entries exceeding maxRetryCount are dropped;
+ *                       non-retryable errors are never retried
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SimpleCache } from '../src/cache';
+import {
+  TelemetryClient,
+  TelemetryEvent,
+  TelemetryTransport,
+  NoopTelemetryTransport,
+  FetchTelemetryTransport,
+} from '../src/telemetry';
+import { OfflineQueue } from '../src/offline';
+import { QueueEntry } from '../src/types';
+import { ValidationError, NetworkError } from '../src/errors';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeEntry(id = '1'): Omit<QueueEntry, 'id' | 'timestamp' | 'retryCount'> {
+  return { method: 'GET', path: '/api/v1/test' };
+}
+
+// ─── #257 SimpleCache ─────────────────────────────────────────────────────────
+
+describe('#257 SimpleCache — eviction on set()', () => {
+  it('evicts the oldest entry when a NEW key is inserted at capacity', () => {
+    const cache = new SimpleCache({ maxEntries: 2 });
+    cache.set('a', 'value-a', 60_000);
+    cache.set('b', 'value-b', 60_000);
+    // Insert a third, genuinely new key — 'a' (oldest) should be evicted
+    cache.set('c', 'value-c', 60_000);
+
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).not.toBeUndefined();
+    expect(cache.get('c')).not.toBeUndefined();
+  });
+
+  it('does NOT evict any entry when updating an existing key at capacity', () => {
+    const cache = new SimpleCache({ maxEntries: 2 });
+    cache.set('a', 'value-a', 60_000);
+    cache.set('b', 'value-b', 60_000);
+
+    // Update 'a' — the map size stays at 2, so no eviction should happen
+    cache.set('a', 'value-a-updated', 60_000);
+
+    expect(cache.get('a')?.value).toBe('value-a-updated');
+    expect(cache.get('b')).not.toBeUndefined();
+  });
+
+  it('reflects the updated value after an in-place update', () => {
+    const cache = new SimpleCache({ maxEntries: 3 });
+    cache.set('x', 'original', 60_000);
+    cache.set('x', 'updated', 60_000);
+
+    expect(cache.get('x')?.value).toBe('updated');
+  });
+});
+
+// ─── #258 TelemetryClient — no endpoint ──────────────────────────────────────
+
+describe('#258 TelemetryClient — unbounded queue with no endpoint', () => {
+  it('is disabled by default when no endpoint is configured', () => {
+    const client = new TelemetryClient();
+    expect(client.getQueueSize()).toBe(0);
+    client.record({ method: 'getQuote', responseTimeMs: 10 });
+    // Should remain 0 because the client is disabled
+    expect(client.getQueueSize()).toBe(0);
+  });
+
+  it('queue does not grow unboundedly — stays at 0 with no endpoint', () => {
+    const client = new TelemetryClient();
+    for (let i = 0; i < 500; i++) {
+      client.record({ method: 'getQuote', responseTimeMs: i });
+    }
+    expect(client.getQueueSize()).toBe(0);
+  });
+
+  it('can be explicitly enabled even without an endpoint, but caps at MAX_QUEUE_SIZE', () => {
+    const client = new TelemetryClient({ enabled: true });
+    // Record more than the cap (100)
+    for (let i = 0; i < 150; i++) {
+      client.record({ method: 'getQuote', responseTimeMs: i });
+    }
+    // Queue must never exceed the cap
+    expect(client.getQueueSize()).toBeLessThanOrEqual(100);
+  });
+});
+
+// ─── #259 TelemetryClient — queueing, flush, transports ──────────────────────
+
+describe('#259 TelemetryClient — queueing and flush behaviour', () => {
+  it('queues events when enabled with an endpoint', () => {
+    const client = new TelemetryClient({ endpoint: 'https://telemetry.example.com', enabled: true });
+    client.record({ method: 'getQuote', responseTimeMs: 100 });
+    client.record({ method: 'getStatus', responseTimeMs: 50 });
+    expect(client.getQueueSize()).toBe(2);
+  });
+
+  it('flush() drains the queue', () => {
+    const client = new TelemetryClient({ endpoint: 'https://telemetry.example.com', enabled: true });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+
+    client.record({ method: 'getQuote', responseTimeMs: 100 });
+    expect(client.getQueueSize()).toBe(1);
+
+    client.flush();
+    expect(client.getQueueSize()).toBe(0);
+
+    vi.restoreAllMocks();
+  });
+
+  it('flush() is a no-op when the queue is already empty', () => {
+    const client = new TelemetryClient({ endpoint: 'https://telemetry.example.com', enabled: true });
+    expect(() => client.flush()).not.toThrow();
+    expect(client.getQueueSize()).toBe(0);
+  });
+
+  it('events include sdkVersion, nodeVersion, and platform fields', () => {
+    const sent: TelemetryEvent[] = [];
+    const transport: TelemetryTransport = { send: (e) => sent.push(e) };
+
+    const client = new TelemetryClient({ transport, enabled: true });
+    client.record({ method: 'getQuote', responseTimeMs: 42 });
+    client.flush();
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      method: 'getQuote',
+      responseTimeMs: 42,
+    });
+    expect(typeof sent[0].sdkVersion).toBe('string');
+    expect(typeof sent[0].nodeVersion).toBe('string');
+    expect(typeof sent[0].platform).toBe('string');
+  });
+
+  it('errorType field is included when provided', () => {
+    const sent: TelemetryEvent[] = [];
+    const transport: TelemetryTransport = { send: (e) => sent.push(e) };
+
+    const client = new TelemetryClient({ transport, enabled: true });
+    client.record({ method: 'getStatus', responseTimeMs: 10, errorType: 'NetworkError' });
+    client.flush();
+
+    expect(sent[0].errorType).toBe('NetworkError');
+  });
+});
+
+describe('#259 NoopTelemetryTransport', () => {
+  it('send() does not throw', () => {
+    const transport = new NoopTelemetryTransport();
+    const event: TelemetryEvent = {
+      sdkVersion: '0.1.0',
+      nodeVersion: 'v20.0.0',
+      platform: 'linux',
+      method: 'getQuote',
+      responseTimeMs: 10,
+    };
+    expect(() => transport.send(event)).not.toThrow();
+  });
+});
+
+describe('#259 FetchTelemetryTransport', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls fetch with correct URL, method, and headers', () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const transport = new FetchTelemetryTransport('https://telemetry.example.com/events');
+    const event: TelemetryEvent = {
+      sdkVersion: '0.1.0',
+      nodeVersion: 'v20.0.0',
+      platform: 'linux',
+      method: 'getQuote',
+      responseTimeMs: 55,
+    };
+
+    transport.send(event);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://telemetry.example.com/events');
+    expect(init.method).toBe('POST');
+    expect(init.headers['Content-Type']).toBe('application/json');
+    expect(JSON.parse(init.body)).toMatchObject({ method: 'getQuote', responseTimeMs: 55 });
+  });
+
+  it('swallows fetch errors silently', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+
+    const transport = new FetchTelemetryTransport('https://telemetry.example.com/events');
+    const event: TelemetryEvent = {
+      sdkVersion: '0.1.0',
+      nodeVersion: 'v20.0.0',
+      platform: 'linux',
+      method: 'getQuote',
+      responseTimeMs: 10,
+    };
+
+    // Should not throw; errors are caught internally
+    await expect(async () => {
+      transport.send(event);
+      // yield microtask queue so the void promise resolves/rejects
+      await new Promise((r) => setTimeout(r, 0));
+    }).not.toThrow();
+  });
+});
+
+// ─── #260 OfflineQueue — max retries & retryable classification ───────────────
+
+describe('#260 OfflineQueue — max retry count', () => {
+  let queue: OfflineQueue;
+
+  afterEach(() => {
+    queue?.destroy();
+  });
+
+  it('drops an entry after it exceeds maxRetryCount', async () => {
+    let callCount = 0;
+    // Always fail with a retryable error
+    const execute = vi.fn(async (_entry: QueueEntry) => {
+      callCount++;
+      throw new NetworkError('server unreachable');
+    });
+    const checkHealth = vi.fn(async () => true);
+
+    queue = new OfflineQueue(execute, checkHealth, {
+      maxRetryCount: 2,
+      healthCheckIntervalMs: 100_000, // prevent auto-trigger
+    });
+
+    await (queue as unknown as { enqueue: OfflineQueue['enqueue'] }).enqueue(makeEntry());
+
+    // Drive replay manually 3 times
+    const replay = (queue as unknown as { replay: () => Promise<void> }).replay.bind(queue);
+    queue['replaying'] = false;
+    await replay(); // retryCount → 1
+    queue['replaying'] = false;
+    await replay(); // retryCount → 2
+    queue['replaying'] = false;
+    await replay(); // retryCount → 3 > maxRetryCount=2 → dropped
+
+    expect(queue.getQueue()).toHaveLength(0);
+  });
+
+  it('retains an entry that has not yet hit maxRetryCount', async () => {
+    const execute = vi.fn(async (_entry: QueueEntry) => {
+      throw new NetworkError('server unreachable');
+    });
+    const checkHealth = vi.fn(async () => true);
+
+    queue = new OfflineQueue(execute, checkHealth, {
+      maxRetryCount: 3,
+      healthCheckIntervalMs: 100_000,
+    });
+
+    await (queue as unknown as { enqueue: OfflineQueue['enqueue'] }).enqueue(makeEntry());
+
+    const replay = (queue as unknown as { replay: () => Promise<void> }).replay.bind(queue);
+    queue['replaying'] = false;
+    await replay(); // retryCount → 1
+
+    expect(queue.getQueue()).toHaveLength(1);
+    expect(queue.getQueue()[0].retryCount).toBe(1);
+  });
+});
+
+describe('#260 OfflineQueue — non-retryable error classification', () => {
+  let queue: OfflineQueue;
+
+  afterEach(() => {
+    queue?.destroy();
+  });
+
+  it('immediately drops an entry that throws a non-retryable BridgeError (e.g. 400 Validation)', async () => {
+    const execute = vi.fn(async (_entry: QueueEntry) => {
+      throw new ValidationError('invalid address');
+    });
+    const checkHealth = vi.fn(async () => true);
+
+    queue = new OfflineQueue(execute, checkHealth, {
+      maxRetryCount: 5,
+      healthCheckIntervalMs: 100_000,
+    });
+
+    await (queue as unknown as { enqueue: OfflineQueue['enqueue'] }).enqueue(makeEntry());
+
+    const replay = (queue as unknown as { replay: () => Promise<void> }).replay.bind(queue);
+    queue['replaying'] = false;
+    await replay();
+
+    // Should have been dropped immediately without incrementing retryCount
+    expect(queue.getQueue()).toHaveLength(0);
+  });
+
+  it('does NOT drop an entry that throws a retryable NetworkError', async () => {
+    let calls = 0;
+    const execute = vi.fn(async (_entry: QueueEntry) => {
+      calls++;
+      if (calls === 1) throw new NetworkError('connection refused');
+      // Succeeds on second attempt
+    });
+    const checkHealth = vi.fn(async () => true);
+
+    queue = new OfflineQueue(execute, checkHealth, {
+      maxRetryCount: 5,
+      healthCheckIntervalMs: 100_000,
+    });
+
+    await (queue as unknown as { enqueue: OfflineQueue['enqueue'] }).enqueue(makeEntry());
+
+    const replay = (queue as unknown as { replay: () => Promise<void> }).replay.bind(queue);
+    queue['replaying'] = false;
+    await replay(); // fails → retains entry
+
+    expect(queue.getQueue()).toHaveLength(1);
+
+    queue['replaying'] = false;
+    await replay(); // succeeds → entry removed
+
+    expect(queue.getQueue()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
…bugs

#257 – SimpleCache.set() now only evicts the oldest entry when the key being inserted is genuinely new; updating an existing key at capacity no longer triggers a spurious eviction.

#258 – TelemetryClient defaults enabled=false when no endpoint is configured so the queue stays empty for the common BridgeClient pattern. A MAX_QUEUE_SIZE (100) cap provides an additional safety net when the client is explicitly enabled without a flush mechanism.

#259 – Added tests for TelemetryClient queueing, flush(), and both transport implementations (NoopTelemetryTransport, FetchTelemetryTransport). flush() and getQueueSize() are now public for testability.

#260 – OfflineQueue.replay() honours a configurable maxRetryCount (default 3) and drops entries that exceed it. Non-retryable BridgeErrors (e.g. 400 ValidationError) are dropped immediately without incrementing retryCount, matching the classification used by BridgeClient.shouldRetry.

chore: extend .gitignore with vitest snapshots, *.tsbuildinfo, test output artifacts, and editor swap files.

Closes #257
Closes #258
Closes #259
Closes #260

## Summary

<!-- One or two sentences: what does this PR do and why? -->

Fixes # <!-- issue number, if applicable -->

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or correcting tests
- [ ] `docs` — documentation only
- [ ] `chore` — build, CI, dependencies, tooling
- [ ] `contract` — Soroban smart contract change

## Changes

<!-- Bullet list of the concrete changes made -->

-

## Testing

<!-- How was this tested? Which test commands were run? -->

- [ ] `cargo test` (contract changes)
- [ ] `npm run test --workspaces`
- [ ] `npm run build` passes without errors
- [ ] Manual testing (describe below if applicable)

```
# paste relevant test output here if it adds context
```

---

## Code Review Checklist

### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
closes
closes #257 
closes #258 
closes #259 
closes #260 