### PR TITLE
fix: add Jackson JSON handling to Java example, guard Rust hash slice

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -9,7 +9,15 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jackson.version>2.17.2</jackson.version>
   </properties>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/examples/java/src/main/java/com/caddressbridge/BridgeClient.java
+++ b/examples/java/src/main/java/com/caddressbridge/BridgeClient.java
@@ -1,5 +1,9 @@
 package com.caddressbridge;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -15,6 +19,7 @@ public final class BridgeClient {
     private final String baseUrl;
     private final String apiKey;
     private final HttpClient http;
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public BridgeClient(String baseUrl, String apiKey) {
         this.baseUrl = baseUrl.replaceAll("/+$", "");
@@ -28,7 +33,7 @@ public final class BridgeClient {
         return new BridgeClient(baseUrl, apiKey);
     }
 
-    public String request(String method, String path, Map<String, String> query, String jsonBody)
+    public JsonNode request(String method, String path, Map<String, String> query, Object jsonBody)
             throws IOException, InterruptedException, BridgeException {
         String url = baseUrl + path;
         if (query != null && !query.isEmpty()) {
@@ -47,7 +52,7 @@ public final class BridgeClient {
             builder.header("X-API-Key", apiKey);
         }
         if (jsonBody != null) {
-            builder.method(method, HttpRequest.BodyPublishers.ofString(jsonBody));
+            builder.method(method, HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(jsonBody)));
         } else {
             builder.method(method, HttpRequest.BodyPublishers.noBody());
         }
@@ -55,14 +60,18 @@ public final class BridgeClient {
         if (resp.statusCode() < 200 || resp.statusCode() >= 300) {
             throw BridgeException.fromResponse(resp.statusCode(), resp.body());
         }
-        return resp.body();
+        String body = resp.body();
+        if (body == null || body.isBlank()) {
+            return mapper.createObjectNode();
+        }
+        return mapper.readTree(body);
     }
 
-    public String health() throws IOException, InterruptedException, BridgeException {
+    public JsonNode health() throws IOException, InterruptedException, BridgeException {
         return request("GET", "/health", null, null);
     }
 
-    public String getQuote(String sourceAsset, String amount, String targetAddress)
+    public JsonNode getQuote(String sourceAsset, String amount, String targetAddress)
             throws IOException, InterruptedException, BridgeException {
         return request("GET", "/api/v1/quote", Map.of(
                 "sourceAsset", sourceAsset,
@@ -71,29 +80,33 @@ public final class BridgeClient {
         ), null);
     }
 
-    public String prepareFunding(String source, String target, String token, String amount, String memo)
+    public JsonNode prepareFunding(String source, String target, String token, String amount, String memo)
             throws IOException, InterruptedException, BridgeException {
-        String body = String.format(
-                "{\"sourceAddress\":\"%s\",\"targetAddress\":\"%s\",\"tokenAddress\":\"%s\",\"amount\":\"%s\",\"memo\":\"%s\"}",
-                source, target, token, amount, memo
-        );
+        ObjectNode body = mapper.createObjectNode();
+        body.put("sourceAddress", source);
+        body.put("targetAddress", target);
+        body.put("tokenAddress", token);
+        body.put("amount", amount);
+        body.put("memo", memo);
         return request("POST", "/api/v1/fund/prepare", null, body);
     }
 
-    public String submitSignedXdr(String signedXdr)
+    public JsonNode submitSignedXdr(String signedXdr)
             throws IOException, InterruptedException, BridgeException {
-        return request("POST", "/api/v1/fund", null, "{\"signedXdr\":\"" + signedXdr + "\"}");
+        ObjectNode body = mapper.createObjectNode();
+        body.put("signedXdr", signedXdr);
+        return request("POST", "/api/v1/fund", null, body);
     }
 
-    public String getStatus(String txHash) throws IOException, InterruptedException, BridgeException {
+    public JsonNode getStatus(String txHash) throws IOException, InterruptedException, BridgeException {
         return request("GET", "/api/v1/status/" + txHash, null, null);
     }
 
-    public String createMoonpayUrl(String jsonBody) throws IOException, InterruptedException, BridgeException {
+    public JsonNode createMoonpayUrl(Object jsonBody) throws IOException, InterruptedException, BridgeException {
         return request("POST", "/api/v1/offramp/moonpay", null, jsonBody);
     }
 
-    public String createTransakUrl(String jsonBody) throws IOException, InterruptedException, BridgeException {
+    public JsonNode createTransakUrl(Object jsonBody) throws IOException, InterruptedException, BridgeException {
         return request("POST", "/api/v1/offramp/transak", null, jsonBody);
     }
 }

--- a/examples/java/src/main/java/com/caddressbridge/example/Example.java
+++ b/examples/java/src/main/java/com/caddressbridge/example/Example.java
@@ -2,6 +2,9 @@ package com.caddressbridge.example;
 
 import com.caddressbridge.BridgeClient;
 import com.caddressbridge.BridgeException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 public final class Example {
     private static final String MOCK_C_ADDRESS =
@@ -11,6 +14,8 @@ public final class Example {
     private static final String MOCK_TOKEN_ADDRESS =
             "CATOKEN7ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMN";
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     public static void main(String[] args) {
         BridgeClient client = BridgeClient.fromEnv();
         System.out.println("Bridge client ready");
@@ -19,18 +24,31 @@ public final class Example {
             System.out.println("Quote: " + client.getQuote("XLM", "10000000", MOCK_C_ADDRESS));
             System.out.println("Prepared: " + client.prepareFunding(
                     MOCK_G_ADDRESS, MOCK_C_ADDRESS, MOCK_TOKEN_ADDRESS, "10000000", "onboarding"));
-            String funded = client.submitSignedXdr("AAAAAgAAAABexampleSignedTransactionXdr");
+            JsonNode funded = client.submitSignedXdr("AAAAAgAAAABexampleSignedTransactionXdr");
             System.out.println("Funded: " + funded);
-            String hash = funded.replaceAll(".*\"hash\"\\s*:\\s*\"([^\"]+)\".*", "$1");
+            JsonNode hashNode = funded.get("hash");
+            if (hashNode == null || hashNode.isNull()) {
+                throw new BridgeException(0, "submitSignedXdr response did not contain a \"hash\" field");
+            }
+            String hash = hashNode.asText();
             System.out.println("Status: " + client.getStatus(hash));
-            System.out.println("MoonPay: " + client.createMoonpayUrl(String.format(
-                    "{\"walletAddress\":\"%s\",\"currencyCode\":\"xlm\",\"walletNetwork\":\"stellar\","
-                            + "\"baseCurrencyAmount\":100,\"baseCurrencyCode\":\"USD\"}",
-                    MOCK_C_ADDRESS)));
-            System.out.println("Transak: " + client.createTransakUrl(String.format(
-                    "{\"walletAddress\":\"%s\",\"network\":\"stellar\",\"fiatCurrency\":\"USD\","
-                            + "\"cryptoCurrency\":\"XLM\",\"fiatAmount\":100}",
-                    MOCK_C_ADDRESS)));
+
+            ObjectNode moonpayBody = MAPPER.createObjectNode();
+            moonpayBody.put("walletAddress", MOCK_C_ADDRESS);
+            moonpayBody.put("currencyCode", "xlm");
+            moonpayBody.put("walletNetwork", "stellar");
+            moonpayBody.put("baseCurrencyAmount", 100);
+            moonpayBody.put("baseCurrencyCode", "USD");
+            System.out.println("MoonPay: " + client.createMoonpayUrl(moonpayBody));
+
+            ObjectNode transakBody = MAPPER.createObjectNode();
+            transakBody.put("walletAddress", MOCK_C_ADDRESS);
+            transakBody.put("network", "stellar");
+            transakBody.put("fiatCurrency", "USD");
+            transakBody.put("cryptoCurrency", "XLM");
+            transakBody.put("fiatAmount", 100);
+            System.out.println("Transak: " + client.createTransakUrl(transakBody));
+
             System.out.println("All flows completed successfully.");
         } catch (BridgeException e) {
             System.err.printf("Bridge error (%d): %s%n", e.getStatusCode(), e.getMessage());

--- a/examples/rust/examples/bridge.rs
+++ b/examples/rust/examples/bridge.rs
@@ -34,7 +34,11 @@ async fn main() -> Result<(), BridgeError> {
     let funded = client
         .submit_signed_xdr("AAAAAgAAAABexampleSignedTransactionXdr")
         .await?;
-    println!("Fund submitted: {} hash={}...", funded.status, &funded.hash[..16]);
+    println!(
+        "Fund submitted: {} hash={}...",
+        funded.status,
+        &funded.hash[..funded.hash.len().min(16)]
+    );
 
     let status = client.get_status(&funded.hash).await?;
     println!("Transaction status: {}", status.status);


### PR DESCRIPTION
- Java BridgeClient now builds request bodies and parses responses with Jackson instead of String.format/concatenation, preventing malformed or injectable JSON when memo/signedXdr contain quotes or control chars (#289)
- Java example now reads the tx hash from the parsed JSON response instead of a best-effort regex that silently passed through the whole payload on a non-match (#290)
- Added jackson-databind to the Java example's pom.xml so BridgeClient returns parsed JsonNode objects like the Go/Python/Rust examples (#291)
- Rust bridge example now bounds the hash slice with .len().min(16), matching the guarded truncations elsewhere in the file, so a short hash no longer panics (#292)
Closes #289 
Closes #290 
Closes #291 
Closes #292 

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or correcting tests
- [ ] `docs` — documentation only
- [ ] `chore` — build, CI, dependencies, tooling
- [ ] `contract` — Soroban smart contract change

## Changes

<!-- Bullet list of the concrete changes made -->

-

## Testing

<!-- How was this tested? Which test commands were run? -->

- [ ] `cargo test` (contract changes)
- [ ] `npm run test --workspaces`
- [ ] `npm run build` passes without errors
- [ ] Manual testing (describe below if applicable)

```
# paste relevant test output here if it adds context
```

---

## Code Review Checklist

### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
