### PR TITLE
Add transak/withdrawal-router test coverage, fix partnerFee/branding drift, document CEX stub handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,13 @@ router.registerExchange('my-exchange', {
 
 Memo format for tracking: `bridge:{exchange_name}:{c_address_suffix}`
 
+> **`defaultCexHandlers` are non-functional placeholders.** The `binance`, `coinbase`, and
+> `kraken` handlers exported from `cex/withdrawal-router.ts` never call an exchange API — they
+> immediately return a fake `success: true` / `status: 'pending'` result. They exist only to
+> illustrate the handler shape used in the snippet above. Registering them directly instead of
+> supplying your own handler will silently "succeed" without ever calling the exchange or moving
+> funds.
+
 ---
 
 ## Development

--- a/api/src/__tests__/cexWithdrawalRouter.test.ts
+++ b/api/src/__tests__/cexWithdrawalRouter.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  WithdrawalRouter,
+  createCexWithdrawalMemo,
+  parseCexWithdrawalMemo,
+  defaultCexHandlers,
+  WithdrawalRequest,
+} from '../../../cex/withdrawal-router';
+
+const request: WithdrawalRequest = {
+  destinationAddress: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+  asset: 'XLM',
+  amount: '10000000',
+  network: 'stellar',
+};
+
+const cexConfig = { name: 'binance', apiBaseUrl: 'https://api.binance.com' };
+
+describe('WithdrawalRouter', () => {
+  let router: WithdrawalRouter;
+
+  beforeEach(() => {
+    router = new WithdrawalRouter();
+  });
+
+  it('routes a withdrawal to the registered handler', async () => {
+    router.registerExchange('binance', cexConfig, defaultCexHandlers.binance);
+    const result = await router.routeWithdrawal('binance', request);
+    expect(result.success).toBe(true);
+    expect(result.withdrawalId).toContain('bin-');
+    expect(result.status).toBe('pending');
+  });
+
+  it('normalises exchange names to lowercase on register and lookup', async () => {
+    router.registerExchange('Binance', cexConfig, defaultCexHandlers.binance);
+    const result = await router.routeWithdrawal('BINANCE', request);
+    expect(result.success).toBe(true);
+  });
+
+  it('throws for an unregistered exchange', async () => {
+    await expect(router.routeWithdrawal('unknown', request)).rejects.toThrow('unsupported exchange: unknown');
+  });
+
+  it('lists registered exchanges', () => {
+    router.registerExchange('binance', cexConfig, defaultCexHandlers.binance);
+    router.registerExchange('coinbase', cexConfig, defaultCexHandlers.coinbase);
+    expect(router.getSupportedExchanges()).toEqual(['binance', 'coinbase']);
+  });
+
+  it('returns an empty list when no exchanges are registered', () => {
+    expect(router.getSupportedExchanges()).toEqual([]);
+  });
+});
+
+describe('defaultCexHandlers', () => {
+  it('binance returns a placeholder pending result', async () => {
+    const result = await defaultCexHandlers.binance(request, cexConfig);
+    expect(result.success).toBe(true);
+    expect(result.withdrawalId).toMatch(/^bin-/);
+    expect(result.status).toBe('pending');
+    expect(result.estimatedCompletion).toBe('5-30 minutes');
+  });
+
+  it('coinbase returns a placeholder pending result', async () => {
+    const result = await defaultCexHandlers.coinbase(request, cexConfig);
+    expect(result.withdrawalId).toMatch(/^cb-/);
+    expect(result.status).toBe('pending');
+  });
+
+  it('kraken returns a placeholder pending result', async () => {
+    const result = await defaultCexHandlers.kraken(request, cexConfig);
+    expect(result.withdrawalId).toMatch(/^kr-/);
+    expect(result.status).toBe('pending');
+  });
+});
+
+describe('createCexWithdrawalMemo', () => {
+  it('formats the bridge memo with exchange name and address suffix', () => {
+    const memo = createCexWithdrawalMemo('CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM', 'binance');
+    expect(memo).toBe('bridge:binance:AAAAD2KM');
+  });
+
+  it('normalises and truncates non-alphanumeric exchange names', () => {
+    const memo = createCexWithdrawalMemo('CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM', 'My-Exchange!');
+    expect(memo).toBe('bridge:myexchan:AAAAD2KM');
+  });
+});
+
+describe('parseCexWithdrawalMemo', () => {
+  it('parses a well-formed bridge memo', () => {
+    expect(parseCexWithdrawalMemo('bridge:binance:AB12CD34')).toEqual({
+      exchangeName: 'binance',
+      targetSuffix: 'AB12CD34',
+    });
+  });
+
+  it('returns an empty object for a malformed memo', () => {
+    expect(parseCexWithdrawalMemo('not-a-bridge-memo')).toEqual({});
+    expect(parseCexWithdrawalMemo('bridge:onlyonepart')).toEqual({});
+    expect(parseCexWithdrawalMemo('wrong:binance:AB12CD34')).toEqual({});
+  });
+});

--- a/api/src/__tests__/offrampTransak.test.ts
+++ b/api/src/__tests__/offrampTransak.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+
+import { createTransakWidgetUrl } from '../../../offramp/transak';
+
+const config = { apiKey: 'pk_test_key', environment: 'STAGING' as const };
+const walletAddress = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+
+describe('createTransakWidgetUrl (offramp module)', () => {
+  it('builds a staging URL with required params', () => {
+    const url = createTransakWidgetUrl(config, { walletAddress });
+    expect(url).toContain('https://global-stg.transak.com?');
+    expect(url).toContain(`apiKey=${config.apiKey}`);
+    expect(url).toContain(`walletAddress=${walletAddress}`);
+    expect(url).toContain('network=stellar');
+  });
+
+  it('uses the production endpoint when configured', () => {
+    const url = createTransakWidgetUrl({ ...config, environment: 'PRODUCTION' }, { walletAddress });
+    expect(url).toContain('https://global.transak.com?');
+  });
+
+  it('includes optional params when provided', () => {
+    const url = createTransakWidgetUrl(config, {
+      walletAddress,
+      network: 'ethereum',
+      fiatCurrency: 'USD',
+      cryptoCurrency: 'USDC',
+      fiatAmount: 100,
+      email: 'test@example.com',
+      redirectUrl: 'https://example.com/callback',
+      partnerFee: 1.5,
+    });
+    expect(url).toContain('network=ethereum');
+    expect(url).toContain('fiatCurrency=USD');
+    expect(url).toContain('cryptoCurrency=USDC');
+    expect(url).toContain('fiatAmount=100');
+    expect(url).toContain('email=test%40example.com');
+    expect(url).toContain('redirectURL=https%3A%2F%2Fexample.com%2Fcallback');
+    expect(url).toContain('partnerFee=1.5');
+  });
+
+  it('omits optional params when not provided', () => {
+    const url = createTransakWidgetUrl(config, { walletAddress });
+    expect(url).not.toContain('fiatCurrency');
+    expect(url).not.toContain('cryptoCurrency');
+    expect(url).not.toContain('fiatAmount');
+    expect(url).not.toContain('email');
+    expect(url).not.toContain('redirectURL');
+    expect(url).not.toContain('partnerFee');
+  });
+
+  it('always sets the branded theme color', () => {
+    const url = createTransakWidgetUrl(config, { walletAddress });
+    expect(url).toContain('themeColor=%237C3AED');
+  });
+});

--- a/api/src/routes/offramp.ts
+++ b/api/src/routes/offramp.ts
@@ -26,6 +26,8 @@ const transakSchema = z.object({
   fiatAmount: z.number().positive().optional(),
   email: z.string().email().optional(),
   redirectURL: z.string().optional(),
+  partnerFee: z.number().positive().optional(),
+  themeColor: z.string().optional(),
 });
 
 offrampRouter.post('/moonpay', async (req: Request, res: Response, next: NextFunction) => {

--- a/api/src/services/__tests__/transak.test.ts
+++ b/api/src/services/__tests__/transak.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('TransakService', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.TRANSAK_API_KEY = 'test-key';
+    process.env.TRANSAK_ENVIRONMENT = 'STAGING';
+  });
+
+  it('generates a widget url', async () => {
+    const { TransakService } = await import('../transak');
+    const service = new TransakService();
+    const url = service.generateWidgetUrl({
+      walletAddress: 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+      network: 'stellar',
+    });
+    expect(url).toContain('global-stg.transak.com');
+    expect(url).toContain('apiKey=test-key');
+    expect(url).toContain('walletAddress=');
+  });
+
+  it('supports setting a partner fee', async () => {
+    const { TransakService } = await import('../transak');
+    const service = new TransakService();
+    const url = service.generateWidgetUrl({
+      walletAddress: 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+      network: 'stellar',
+      partnerFee: 1.5,
+    });
+    expect(url).toContain('partnerFee=1.5');
+  });
+
+  it('defaults to the standard branded theme color', async () => {
+    const { TransakService } = await import('../transak');
+    const service = new TransakService();
+    const url = service.generateWidgetUrl({
+      walletAddress: 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+      network: 'stellar',
+    });
+    expect(url).toContain('themeColor=%237C3AED');
+  });
+
+  it('allows overriding the theme color', async () => {
+    const { TransakService } = await import('../transak');
+    const service = new TransakService();
+    const url = service.generateWidgetUrl({
+      walletAddress: 'CABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW',
+      network: 'stellar',
+      themeColor: '#000000',
+    });
+    expect(url).toContain('themeColor=%23000000');
+  });
+});

--- a/api/src/services/transak.ts
+++ b/api/src/services/transak.ts
@@ -9,6 +9,10 @@ interface TransakWidgetParams {
   fiatAmount?: number;
   email?: string;
   redirectURL?: string;
+  /** Optional partner fee percentage to display in the widget. */
+  partnerFee?: number;
+  /** Widget branding color (hex). Defaults to the standard bridge brand color. */
+  themeColor?: string;
 }
 
 /** Handles Transak widget URL generation for fiat on-ramp flows. */
@@ -44,6 +48,8 @@ export class TransakService {
     if (params.fiatAmount) queryParams.set('fiatAmount', params.fiatAmount.toString());
     if (params.email) queryParams.set('email', params.email);
     if (params.redirectURL) queryParams.set('redirectURL', params.redirectURL);
+    if (params.partnerFee) queryParams.set('partnerFee', params.partnerFee.toString());
+    queryParams.set('themeColor', params.themeColor ?? '#7C3AED');
 
     return `${baseUrl}?${queryParams.toString()}`;
   }

--- a/cex/README.md
+++ b/cex/README.md
@@ -44,6 +44,13 @@ router.registerExchange('your-exchange', {
 });
 ```
 
+> **`defaultCexHandlers` are non-functional placeholders.** `binance`, `coinbase`, and `kraken`
+> in `defaultCexHandlers` never call an exchange API — they immediately return a fake
+> `success: true` / `status: 'pending'` result. They exist only to illustrate the handler
+> shape shown above. Registering them directly with `WithdrawalRouter` (instead of writing your
+> own handler, as shown in the snippet) will silently "succeed" without ever moving funds. Always
+> implement and register your own handler before routing real withdrawals.
+
 2. Use the bridge memo format for tracking:
 - Format: `bridge:{exchange_name}:{c_address_suffix}`
 - Example: `bridge:binance:AB12CD34`


### PR DESCRIPTION
- Add tests for offramp/transak.ts createTransakWidgetUrl (#281)
- Add partnerFee and themeColor to api/src/services/transak.ts so it matches the standalone offramp module, and expose them on the /offramp/transak route schema (#282)
- Add tests for cex/withdrawal-router.ts (#283)
- Document in cex/README.md and root README.md that defaultCexHandlers are non-functional placeholders that never call a real exchange API (#284)
Closes #281 
Closes #282 
Closes #283 
Closes #284 

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `perf` — performance improvement
- [ ] `test` — adding or correcting tests
- [ ] `docs` — documentation only
- [ ] `chore` — build, CI, dependencies, tooling
- [ ] `contract` — Soroban smart contract change

## Changes

<!-- Bullet list of the concrete changes made -->

-

## Testing

<!-- How was this tested? Which test commands were run? -->

- [ ] `cargo test` (contract changes)
- [ ] `npm run test --workspaces`
- [ ] `npm run build` passes without errors
- [ ] Manual testing (describe below if applicable)

```
# paste relevant test output here if it adds context
```

---

## Code Review Checklist

### General

- [ ] Code follows the project's TypeScript / Rust conventions (see `CONTRIBUTING.md`)
- [ ] No `console.log`, `dbg!`, `println!`, or other debug output left in
- [ ] No `TODO` or `FIXME` comments added without a linked issue
- [ ] No new `any` types introduced in TypeScript
- [ ] No new `unsafe` blocks in Rust without documented justification
- [ ] No hardcoded secrets, addresses, or credentials

### Tests

- [ ] New behaviour is covered by unit tests
- [ ] Edge cases and error paths are tested
- [ ] Integration / E2E tests updated if the API contract changed
- [ ] Fuzz targets updated if input parsing changed (contract)

### API & Contract Changes

- [ ] API changes are documented in `docs/api-reference/openapi.json`
- [ ] SDK `BridgeClient` updated if a new endpoint was added
- [ ] Contract interface changes are reflected in `contracts/onboarding-bridge/UPGRADE.md`
- [ ] Database schema changes include a migration script under `api/src/migrations/`
- [ ] Breaking changes noted in the PR description with a migration path

### Security

- [ ] No new secrets or sensitive values logged
- [ ] Authentication / authorization checked on any new or modified endpoints
- [ ] Input validation present for all user-supplied values
- [ ] Rate limiting applied to new high-cost endpoints

### Documentation

- [ ] Public functions / methods have JSDoc (TypeScript) or `///` doc comments (Rust)
- [ ] `README.md` or relevant `docs/` page updated if user-visible behaviour changed
- [ ] `CHANGELOG.md` entry added for user-facing changes (feat / fix / perf / breaking)

---

## Screenshots / recordings

<!-- Optional: attach screenshots for UI-adjacent changes, or terminal output for CLI changes -->

## Additional context

<!-- Anything the reviewer needs to know that isn't obvious from the diff -->
