### PR TITLE
Test/coverage min max admin reentrancy rebate

### DIFF
--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1690,6 +1690,13 @@ fn test_set_rebate_tier_basic() {
 }
 
 #[test]
+#[should_panic(expected = "discount capped at 50%")]
+fn test_set_rebate_tier_rejects_discount_above_cap() {
+    let (_env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
+    bridge.set_rebate_tier(&0, &1000i128, &5001); // > 5000 bps (50%)
+}
+
+#[test]
 fn test_user_volume_tracks_funding() {
     let (env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
     let source = Address::generate(&env);

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -566,6 +566,19 @@ fn test_initialize_validates_admins_not_empty() {
 }
 
 #[test]
+#[should_panic(expected = "admin address cannot be the contract address")]
+fn test_initialize_rejects_admin_equal_to_contract_address() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let bridge_id = env.register_contract(None, OnboardingBridge);
+    let bridge = OnboardingBridgeClient::new(&env, &bridge_id);
+
+    let mut admins: Vec<Address> = Vec::new(&env);
+    admins.push_back(bridge_id.clone());
+    bridge.initialize(&admins, &1, &50, &1000, &1, &i128::MAX);
+}
+
+#[test]
 #[should_panic(expected = "amount must be positive")]
 fn test_fund_c_address_zero_amount() {
     let (env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -134,6 +134,107 @@ impl TestToken {
 }
 
 // ---------------------------------------------------------------------------
+// Malicious reentrant test token — attempts to call back into the bridge's
+// fund_c_address from within its own transfer() callback, so the
+// reentrancy guard can be genuinely exercised (not just asserted absent).
+// ---------------------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone)]
+enum MTK {
+    Bal(Address),
+    ReentryConfig,
+}
+
+#[contracttype]
+#[derive(Clone)]
+struct ReentryConfig {
+    bridge: Address,
+    source: Address,
+    target: Address,
+    token_addr: Address,
+}
+
+#[contract]
+struct MaliciousToken;
+
+#[contractimpl]
+impl MaliciousToken {
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let bal: i128 = env
+            .storage()
+            .persistent()
+            .get::<MTK, i128>(&MTK::Bal(to.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(&MTK::Bal(to), &(bal + amount));
+    }
+
+    /// Arms the token: the next transfer() call will attempt to reenter
+    /// `fund_c_address` on `bridge` using the given call arguments.
+    pub fn configure(env: Env, bridge: Address, source: Address, target: Address, token_addr: Address) {
+        env.storage().instance().set(
+            &MTK::ReentryConfig,
+            &ReentryConfig {
+                bridge,
+                source,
+                target,
+                token_addr,
+            },
+        );
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get::<MTK, i128>(&MTK::Bal(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+
+        if let Some(cfg) = env
+            .storage()
+            .instance()
+            .get::<MTK, ReentryConfig>(&MTK::ReentryConfig)
+        {
+            let bridge = OnboardingBridgeClient::new(&env, &cfg.bridge);
+            let memo = String::from_str(&env, "reentrant");
+            // This nested call must be rejected by the bridge's reentrancy guard.
+            bridge.fund_c_address(&cfg.source, &cfg.target, &cfg.token_addr, &amount, &memo);
+        }
+
+        let fb: i128 = env
+            .storage()
+            .persistent()
+            .get::<MTK, i128>(&MTK::Bal(from.clone()))
+            .unwrap_or(0);
+        assert!(fb >= amount, "insufficient balance");
+        let tb: i128 = env
+            .storage()
+            .persistent()
+            .get::<MTK, i128>(&MTK::Bal(to.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&MTK::Bal(from), &(fb - amount));
+        env.storage().persistent().set(&MTK::Bal(to), &(tb + amount));
+    }
+
+    pub fn decimals(_env: Env) -> u32 {
+        7
+    }
+
+    pub fn name(env: Env) -> String {
+        String::from_str(&env, "MaliciousToken")
+    }
+
+    pub fn symbol(env: Env) -> String {
+        String::from_str(&env, "EVIL")
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
@@ -1488,7 +1589,7 @@ fn test_token_transfer_direct() {
 // ===========================================================================
 
 #[test]
-fn test_reentrancy_guard_on_fund_c_address() {
+fn test_fund_c_address_normal_path_unaffected_by_guard() {
     let (env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
     let source = Address::generate(&env);
     let target = Address::generate(&env);
@@ -1503,6 +1604,39 @@ fn test_reentrancy_guard_on_fund_c_address() {
         &String::from_str(&env, "normal"),
     );
     assert_eq!(fee, 10);
+}
+
+/// Genuinely exercises the reentrancy guard: a malicious token's transfer()
+/// callback attempts to reenter `fund_c_address` on the bridge mid-call.
+/// The guard set in `fund_c_address` before invoking `tk.transfer` must
+/// cause the nested call to panic with ERR_REENTRANT_CALL.
+#[test]
+#[should_panic(expected = "reentrant call detected")]
+fn test_reentrancy_guard_blocks_malicious_token_callback() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let bridge_id = env.register_contract(None, OnboardingBridge);
+    let bridge = OnboardingBridgeClient::new(&env, &bridge_id);
+    let admins = create_admins(&env, 1);
+    bridge.initialize(&admins, &1, &100, &1000, &1, &i128::MAX);
+
+    let evil_token = env.register_contract(None, MaliciousToken);
+    let evil_client = MaliciousTokenClient::new(&env, &evil_token);
+    evil_client.mint(&source, &2000);
+    // Arm the token to reenter fund_c_address during its own transfer callback.
+    evil_client.configure(&bridge_id, &source, &target, &evil_token);
+
+    bridge.fund_c_address(
+        &source,
+        &target,
+        &evil_token,
+        &1000,
+        &String::from_str(&env, "attack"),
+    );
 }
 
 // ===========================================================================

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1577,3 +1577,45 @@ fn test_initialize_with_custom_amounts() {
     assert_eq!(bridge.min_amount(), 50);
     assert_eq!(bridge.max_amount(), 1_000_000);
 }
+
+#[test]
+#[should_panic(expected = "amount below minimum")]
+fn test_fund_c_address_below_min_amount_panics() {
+    let (env, bridge) = setup_env();
+    let admins = create_admins(&env, 1);
+    bridge.initialize(&admins, &1, &100, &1000, &500, &10_000);
+
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+    let token_addr = register_test_token(&env);
+    TestTokenClient::new(&env, &token_addr).mint(&source, &10_000);
+
+    bridge.fund_c_address(
+        &source,
+        &target,
+        &token_addr,
+        &100, // below min_amount of 500
+        &String::from_str(&env, "below min"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "amount above maximum")]
+fn test_fund_c_address_above_max_amount_panics() {
+    let (env, bridge) = setup_env();
+    let admins = create_admins(&env, 1);
+    bridge.initialize(&admins, &1, &100, &1000, &500, &10_000);
+
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+    let token_addr = register_test_token(&env);
+    TestTokenClient::new(&env, &token_addr).mint(&source, &1_000_000);
+
+    bridge.fund_c_address(
+        &source,
+        &target,
+        &token_addr,
+        &20_000, // above max_amount of 10_000
+        &String::from_str(&env, "above max"),
+    );
+}


### PR DESCRIPTION
Closes #245 
Closes #246 
Closes #247 
Closes #248 

Summary of what was implemented:

1. test: cover fund_c_address_internal min/max amount bounds — two #[should_panic] tests funding below min_amount (500) and above max_amount (10,000), each asserting the specific panic message ("amount below minimum" / "amount above maximum").
2. test: cover validate_admins rejecting the contract's own address — initializes with the contract's own registered address in the admin list, asserting it panics with "admin address cannot be the contract address".
3. test: genuinely exercise the reentrancy guard with a malicious token — added a MaliciousToken mock contract whose transfer() callback reenters bridge.fund_c_address mid-call. The test arms it, funds through it, and asserts the nested call panics with "reentrant call detected" — actually proving the guard works rather than just calling fund_c_address once. Kept the original single-call assertion as a separate normal-path sanity test.
4. test: cover set_rebate_tier discount cap above 5000 bps — attempts a 5001 bps tier and asserts it panics with "discount capped at 50%".