### PR TITLE
Fix Rust status-check ordering, add error-mapping tests, wire up real API deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # ── Dev: auto-deploy on every push to main ─────────────────────────────────
+  # ── Dev: auto-deploy on every push to main (single target, fast iteration) ──
   deploy-dev:
     name: Deploy → dev
     runs-on: ubuntu-latest
@@ -89,16 +89,13 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NODE_ENV: development
 
-      - name: Deploy
+      - name: Deploy API
         if: env.DEPLOY_HOST != ''
-        run: bash scripts/deploy.sh
+        run: bash scripts/deploy-api.sh
         env:
-          ENVIRONMENT: dev
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          SOURCE_ACCOUNT: ${{ secrets.SOROBAN_SOURCE_ACCOUNT }}
-          SOROBAN_RPC_URL: ${{ vars.SOROBAN_RPC_URL }}
 
       - name: Smoke tests
         if: env.DEPLOY_HOST != ''
@@ -109,13 +106,12 @@ jobs:
 
       - name: Rollback on failure
         if: failure() && env.DEPLOY_HOST != ''
-        run: bash scripts/deploy.sh --rollback
+        run: bash scripts/deploy-api.sh --rollback
         env:
-          ENVIRONMENT: dev
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
 
-  # ── Staging: manual promote ────────────────────────────────────────────────
+  # ── Staging: manual promote, blue/green for zero-downtime releases ────────
   deploy-staging:
     name: Deploy → staging
     runs-on: ubuntu-latest
@@ -133,33 +129,39 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NODE_ENV: staging
 
-      - name: Deploy
-        run: bash scripts/deploy.sh
+      - name: Restore blue/green state
+        uses: actions/cache/restore@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-staging
+          restore-keys: blue-green-state-staging-
+
+      - name: Blue/green deploy
+        run: bash scripts/blue-green-deploy.sh
         env:
-          ENVIRONMENT: staging
+          BLUE_URL: ${{ vars.BLUE_APP_URL }}
+          GREEN_URL: ${{ vars.GREEN_APP_URL }}
+          BLUE_DEPLOY_HOST: ${{ secrets.BLUE_DEPLOY_HOST }}
+          GREEN_DEPLOY_HOST: ${{ secrets.GREEN_DEPLOY_HOST }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || needs.build.outputs.image_tag }}
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          SOURCE_ACCOUNT: ${{ secrets.SOROBAN_SOURCE_ACCOUNT }}
-          SOROBAN_RPC_URL: ${{ vars.SOROBAN_RPC_URL }}
-
-      - name: Smoke tests
-        run: bash scripts/smoke-test.sh
-        env:
-          APP_URL: ${{ vars.APP_URL }}
+          DEPLOY_BLUE_COMMAND: DEPLOY_HOST="$BLUE_DEPLOY_HOST" bash scripts/deploy-api.sh
+          DEPLOY_GREEN_COMMAND: DEPLOY_HOST="$GREEN_DEPLOY_HOST" bash scripts/deploy-api.sh
+          SMOKE_TEST_SCRIPT: scripts/smoke-test.sh
           SMOKE_API_KEY: ${{ secrets.SMOKE_API_KEY }}
+          POST_SWITCH_CHECK_COMMAND: bash scripts/smoke-test.sh
+          DRAIN_GRACE_SECONDS: '30'
+          WARMUP_WINDOW_SECONDS: '60'
 
-      - name: Rollback on failure
-        if: failure()
-        run: bash scripts/deploy.sh --rollback
-        env:
-          ENVIRONMENT: staging
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      - name: Save blue/green state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-staging-${{ github.run_id }}
 
-  # ── Production: 2-approver manual promote ─────────────────────────────────
+  # ── Production: 2-approver manual promote, blue/green for zero-downtime ───
   deploy-production:
     name: Deploy → production
     runs-on: ubuntu-latest
@@ -177,29 +179,33 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NODE_ENV: production
 
-      - name: Deploy
-        run: bash scripts/deploy.sh
+      - name: Restore blue/green state
+        uses: actions/cache/restore@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-production
+          restore-keys: blue-green-state-production-
+
+      - name: Blue/green deploy
+        run: bash scripts/blue-green-deploy.sh
         env:
-          ENVIRONMENT: production
+          BLUE_URL: ${{ vars.BLUE_APP_URL }}
+          GREEN_URL: ${{ vars.GREEN_APP_URL }}
+          BLUE_DEPLOY_HOST: ${{ secrets.BLUE_DEPLOY_HOST }}
+          GREEN_DEPLOY_HOST: ${{ secrets.GREEN_DEPLOY_HOST }}
           IMAGE_TAG: ${{ github.event.inputs.image_tag || needs.build.outputs.image_tag }}
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
-          SOURCE_ACCOUNT: ${{ secrets.SOROBAN_SOURCE_ACCOUNT }}
-          SOROBAN_RPC_URL: ${{ vars.SOROBAN_RPC_URL }}
-          SOROBAN_NETWORK_PASSPHRASE: ${{ secrets.SOROBAN_NETWORK_PASSPHRASE }}
-
-      - name: Smoke tests
-        run: bash scripts/smoke-test.sh
-        env:
-          APP_URL: ${{ vars.APP_URL }}
+          DEPLOY_BLUE_COMMAND: DEPLOY_HOST="$BLUE_DEPLOY_HOST" bash scripts/deploy-api.sh
+          DEPLOY_GREEN_COMMAND: DEPLOY_HOST="$GREEN_DEPLOY_HOST" bash scripts/deploy-api.sh
+          SMOKE_TEST_SCRIPT: scripts/smoke-test.sh
           SMOKE_API_KEY: ${{ secrets.SMOKE_API_KEY }}
+          POST_SWITCH_CHECK_COMMAND: bash scripts/smoke-test.sh
+          SWITCH_TRAFFIC_COMMAND: ${{ vars.SWITCH_TRAFFIC_COMMAND }}
 
-      - name: Rollback on failure
-        if: failure()
-        run: bash scripts/deploy.sh --rollback
-        env:
-          ENVIRONMENT: production
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+      - name: Save blue/green state
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-production-${{ github.run_id }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -24,13 +24,50 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Rollback deploy
-        run: bash scripts/deploy.sh --rollback --steps "${{ github.event.inputs.steps }}"
+      # ── dev: single target, roll back directly ─────────────────────────────
+      - name: Rollback deploy (dev)
+        if: github.event.inputs.environment == 'dev'
+        run: bash scripts/deploy-api.sh --rollback
         env:
-          ENVIRONMENT: ${{ github.event.inputs.environment }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+
+      # ── staging/production: blue/green — flip traffic back to the other color ──
+      - name: Restore blue/green state
+        if: github.event.inputs.environment != 'dev'
+        uses: actions/cache/restore@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-${{ github.event.inputs.environment }}
+          restore-keys: blue-green-state-${{ github.event.inputs.environment }}-
+
+      - name: Rollback deploy (blue/green)
+        if: github.event.inputs.environment != 'dev'
+        run: bash scripts/blue-green-deploy.sh
+        env:
+          BLUE_URL: ${{ vars.BLUE_APP_URL }}
+          GREEN_URL: ${{ vars.GREEN_APP_URL }}
+          BLUE_DEPLOY_HOST: ${{ secrets.BLUE_DEPLOY_HOST }}
+          GREEN_DEPLOY_HOST: ${{ secrets.GREEN_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+          # Rolling back re-asserts each host's previously-running image
+          # rather than shipping IMAGE_TAG, then switches traffic to it.
+          DEPLOY_BLUE_COMMAND: DEPLOY_HOST="$BLUE_DEPLOY_HOST" bash scripts/deploy-api.sh --rollback
+          DEPLOY_GREEN_COMMAND: DEPLOY_HOST="$GREEN_DEPLOY_HOST" bash scripts/deploy-api.sh --rollback
+          SMOKE_TEST_SCRIPT: scripts/smoke-test.sh
+          SMOKE_API_KEY: ${{ secrets.SMOKE_API_KEY }}
+          POST_SWITCH_CHECK_COMMAND: bash scripts/smoke-test.sh
+          SWITCH_TRAFFIC_COMMAND: ${{ vars.SWITCH_TRAFFIC_COMMAND }}
+          WARMUP_WINDOW_SECONDS: '0'
+
+      - name: Save blue/green state
+        if: always() && github.event.inputs.environment != 'dev'
+        uses: actions/cache/save@v4
+        with:
+          path: deployments/blue-green-state.txt
+          key: blue-green-state-${{ github.event.inputs.environment }}-${{ github.run_id }}
 
       - name: Rollback migrations
         run: npm run migrate:rollback -w api -- "${{ github.event.inputs.steps }}"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __snapshots__/
 .vitest-cache/
 *.tsbuildinfo
 deployments/*.json
+deployments/blue-green-state.txt
 .secrets.local.json
 .secrets.local.enc
 logs/secrets-audit.jsonl

--- a/README.md
+++ b/README.md
@@ -724,10 +724,22 @@ docker run -p 3001:3001 --env-file .env c-address-bridge-api
 
 ### Blue-Green Deployment
 
+`deploy.yml` runs blue/green deploys for staging and production automatically —
+see [scripts/blue-green-deploy.sh](scripts/blue-green-deploy.sh) and
+[scripts/deploy-api.sh](scripts/deploy-api.sh) (the latter ships the API Docker
+image to a single host over SSH; the former orchestrates it across both
+colors). To run it manually:
+
 ```bash
 export BLUE_URL=https://blue.example.com
 export GREEN_URL=https://green.example.com
-export DEPLOY_GREEN_COMMAND='bash ./scripts/deploy.sh --network testnet'
+export BLUE_DEPLOY_HOST=blue.internal.example.com
+export GREEN_DEPLOY_HOST=green.internal.example.com
+export DEPLOY_USER=deploy
+export DEPLOY_KEY="$(cat ~/.ssh/deploy_key)"
+export IMAGE_TAG=sha-abc1234
+export DEPLOY_BLUE_COMMAND='DEPLOY_HOST="$BLUE_DEPLOY_HOST" bash scripts/deploy-api.sh'
+export DEPLOY_GREEN_COMMAND='DEPLOY_HOST="$GREEN_DEPLOY_HOST" bash scripts/deploy-api.sh'
 export SWITCH_TRAFFIC_COMMAND='echo "switch traffic to {{color}}"'
 export POST_SWITCH_CHECK_COMMAND='bash ./scripts/smoke-test.sh'
 
@@ -735,6 +747,25 @@ npm run deploy:blue-green
 ```
 
 The blue-green flow deploys to the inactive environment, runs smoke tests, switches traffic, keeps the previous environment warm for rollback, drains old connections, and records the active color for the next release.
+
+In CI, `SWITCH_TRAFFIC_COMMAND` should point at your load balancer / DNS
+integration (set it as the `SWITCH_TRAFFIC_COMMAND` repository or environment
+variable); until it's configured, the workflow only records the active color
+and logs that no traffic switch was performed.
+
+#### Required GitHub secrets/variables for `deploy.yml` / `rollback.yml`
+
+| Name | Kind | Used by | Description |
+|------|------|---------|-------------|
+| `DEPLOY_HOST` | secret | dev | SSH host for the single-target dev deploy |
+| `DEPLOY_USER` | secret | dev, staging, production | SSH user for `scripts/deploy-api.sh` |
+| `DEPLOY_KEY` | secret | dev, staging, production | SSH private key (PEM content) |
+| `BLUE_DEPLOY_HOST` / `GREEN_DEPLOY_HOST` | secret | staging, production | SSH hosts for each blue/green color |
+| `DATABASE_URL` | secret | all | Used for `npm run migrate` |
+| `SMOKE_API_KEY` | secret | all | Optional — authenticated smoke test check |
+| `APP_URL` | variable | all | Public URL used for the GitHub Environment link and smoke tests |
+| `BLUE_APP_URL` / `GREEN_APP_URL` | variable | staging, production | Per-color URLs used for deploy + smoke tests before the traffic switch |
+| `SWITCH_TRAFFIC_COMMAND` | variable | production | Shell command that flips your load balancer / DNS to `{{color}}` |
 
 ---
 

--- a/examples/go/caddressbridge/client_test.go
+++ b/examples/go/caddressbridge/client_test.go
@@ -1,0 +1,172 @@
+package caddressbridge
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestClient(handler http.HandlerFunc) (*BridgeClient, func()) {
+	srv := httptest.NewServer(handler)
+	c := NewClient(srv.URL, "")
+	return c, srv.Close
+}
+
+func jsonHandler(status int, body map[string]any) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+func TestRequest_SuccessReturnsBody(t *testing.T) {
+	client, closeSrv := newTestClient(jsonHandler(http.StatusOK, map[string]any{"status": "ok"}))
+	defer closeSrv()
+
+	out, err := client.Health()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["status"] != "ok" {
+		t.Fatalf("expected status ok, got %v", out["status"])
+	}
+}
+
+func TestRequest_MapsAuthErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		client, closeSrv := newTestClient(jsonHandler(status, map[string]any{"message": "nope", "code": "AUTH"}))
+
+		_, err := client.Health()
+		closeSrv()
+
+		var bErr *BridgeError
+		if !errors.As(err, &bErr) {
+			t.Fatalf("status %d: expected *BridgeError, got %T (%v)", status, err, err)
+		}
+		if bErr.Status != status {
+			t.Fatalf("expected status %d, got %d", status, bErr.Status)
+		}
+		if bErr.Message != "nope" {
+			t.Fatalf("expected message 'nope', got %q", bErr.Message)
+		}
+		if bErr.Code != "AUTH" {
+			t.Fatalf("expected code 'AUTH', got %q", bErr.Code)
+		}
+	}
+}
+
+func TestRequest_MapsValidationErrors(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusUnprocessableEntity} {
+		client, closeSrv := newTestClient(jsonHandler(status, map[string]any{"message": "bad input"}))
+
+		_, err := client.Health()
+		closeSrv()
+
+		var bErr *BridgeError
+		if !errors.As(err, &bErr) {
+			t.Fatalf("status %d: expected *BridgeError, got %T (%v)", status, err, err)
+		}
+		if bErr.Status != status {
+			t.Fatalf("expected status %d, got %d", status, bErr.Status)
+		}
+		if bErr.Message != "bad input" {
+			t.Fatalf("expected message 'bad input', got %q", bErr.Message)
+		}
+	}
+}
+
+func TestRequest_MapsNotFound(t *testing.T) {
+	client, closeSrv := newTestClient(jsonHandler(http.StatusNotFound, map[string]any{"message": "missing"}))
+	defer closeSrv()
+
+	_, err := client.Health()
+
+	var bErr *BridgeError
+	if !errors.As(err, &bErr) {
+		t.Fatalf("expected *BridgeError, got %T (%v)", err, err)
+	}
+	if bErr.Status != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", bErr.Status)
+	}
+}
+
+func TestRequest_MapsRateLimit(t *testing.T) {
+	client, closeSrv := newTestClient(jsonHandler(http.StatusTooManyRequests, map[string]any{"message": "slow down"}))
+	defer closeSrv()
+
+	_, err := client.Health()
+
+	var bErr *BridgeError
+	if !errors.As(err, &bErr) {
+		t.Fatalf("expected *BridgeError, got %T (%v)", err, err)
+	}
+	if bErr.Status != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429, got %d", bErr.Status)
+	}
+}
+
+func TestRequest_MapsServerErrors(t *testing.T) {
+	client, closeSrv := newTestClient(jsonHandler(http.StatusInternalServerError, map[string]any{"message": "boom", "code": "INTERNAL"}))
+	defer closeSrv()
+
+	_, err := client.Health()
+
+	var bErr *BridgeError
+	if !errors.As(err, &bErr) {
+		t.Fatalf("expected *BridgeError, got %T (%v)", err, err)
+	}
+	if bErr.Status != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", bErr.Status)
+	}
+	if bErr.Code != "INTERNAL" {
+		t.Fatalf("expected code 'INTERNAL', got %q", bErr.Code)
+	}
+}
+
+func TestRequest_FallsBackToStatusTextWhenMessageMissing(t *testing.T) {
+	client, closeSrv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	defer closeSrv()
+
+	_, err := client.Health()
+
+	var bErr *BridgeError
+	if !errors.As(err, &bErr) {
+		t.Fatalf("expected *BridgeError, got %T (%v)", err, err)
+	}
+	if bErr.Message != http.StatusText(http.StatusBadGateway) && bErr.Message != "502 Bad Gateway" {
+		t.Fatalf("expected fallback message derived from HTTP status, got %q", bErr.Message)
+	}
+}
+
+func TestRequest_BuildsQueryParams(t *testing.T) {
+	var gotQuery string
+	client, closeSrv := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"estimatedFee": "1", "expectedReceive": "2", "feeBps": 30, "rate": "1.0"})
+	})
+	defer closeSrv()
+
+	_, err := client.GetQuote("XLM", "1000", "CTARGET")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotQuery == "" {
+		t.Fatalf("expected query string to be set")
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	err := &BridgeError{Status: 404, Message: "missing"}
+	if err.Error() != "bridge error (404): missing" {
+		t.Fatalf("unexpected Error() output: %q", err.Error())
+	}
+}

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -10,12 +10,19 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.17.2</jackson.version>
+    <junit.version>5.10.3</junit.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
@@ -27,6 +34,11 @@
         <configuration>
           <mainClass>com.caddressbridge.example.Example</mainClass>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.3.1</version>
       </plugin>
     </plugins>
   </build>

--- a/examples/java/src/test/java/com/caddressbridge/BridgeExceptionTest.java
+++ b/examples/java/src/test/java/com/caddressbridge/BridgeExceptionTest.java
@@ -1,0 +1,50 @@
+package com.caddressbridge;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class BridgeExceptionTest {
+
+    @Test
+    void extractsMessageFromJsonBody() {
+        BridgeException ex = BridgeException.fromResponse(401, "{\"message\":\"Unauthorized\",\"code\":\"AUTH\"}");
+        assertEquals(401, ex.getStatusCode());
+        assertEquals("Unauthorized", ex.getMessage());
+    }
+
+    @Test
+    void extractsMessageWhenOtherFieldsPrecedeIt() {
+        BridgeException ex = BridgeException.fromResponse(400, "{\"code\":\"VALIDATION\",\"message\":\"amount is required\",\"fields\":[]}");
+        assertEquals(400, ex.getStatusCode());
+        assertEquals("amount is required", ex.getMessage());
+    }
+
+    @Test
+    void fallsBackToRawBodyWhenNoMessageField() {
+        BridgeException ex = BridgeException.fromResponse(502, "<html>Bad Gateway</html>");
+        assertEquals(502, ex.getStatusCode());
+        assertEquals("<html>Bad Gateway</html>", ex.getMessage());
+    }
+
+    @Test
+    void fallsBackToRawBodyForPlainText() {
+        BridgeException ex = BridgeException.fromResponse(500, "internal server error");
+        assertEquals(500, ex.getStatusCode());
+        assertEquals("internal server error", ex.getMessage());
+    }
+
+    @Test
+    void handlesNullBody() {
+        BridgeException ex = BridgeException.fromResponse(404, null);
+        assertEquals(404, ex.getStatusCode());
+        assertEquals(null, ex.getMessage());
+    }
+
+    @Test
+    void handlesEmptyBody() {
+        BridgeException ex = BridgeException.fromResponse(404, "");
+        assertEquals(404, ex.getStatusCode());
+        assertEquals("", ex.getMessage());
+    }
+}

--- a/examples/python/tests/test_errors.py
+++ b/examples/python/tests/test_errors.py
@@ -1,0 +1,79 @@
+"""Unit tests for client-side HTTP error-mapping logic.
+
+Run from examples/python/:
+    python -m unittest discover -s tests
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from c_address_bridge.errors import (
+    AuthError,
+    BridgeError,
+    NetworkError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+    ValidationError,
+    parse_http_error,
+)
+
+
+class ParseHttpErrorTests(unittest.TestCase):
+    def test_maps_401_and_403_to_auth_error(self) -> None:
+        for status in (401, 403):
+            err = parse_http_error(status, {"message": "nope"})
+            self.assertIsInstance(err, AuthError)
+            self.assertEqual(err.status_code, status)
+            self.assertEqual(str(err), "nope")
+
+    def test_maps_404_to_not_found(self) -> None:
+        err = parse_http_error(404, {"message": "missing"})
+        self.assertIsInstance(err, NotFoundError)
+        self.assertEqual(err.status_code, 404)
+        self.assertEqual(str(err), "missing")
+
+    def test_maps_400_and_422_to_validation_error_with_fields(self) -> None:
+        for status in (400, 422):
+            err = parse_http_error(status, {"message": "bad input", "fields": ["amount"]})
+            self.assertIsInstance(err, ValidationError)
+            self.assertEqual(err.status_code, status)
+            self.assertEqual(err.fields, ["amount"])
+
+    def test_maps_429_to_rate_limit_with_retry_after_ms(self) -> None:
+        err = parse_http_error(429, {"message": "slow down", "retryAfter": 2.5})
+        self.assertIsInstance(err, RateLimitError)
+        self.assertTrue(err.retryable)
+        self.assertEqual(err.retry_after_ms, 2500)
+
+    def test_maps_429_without_retry_after(self) -> None:
+        err = parse_http_error(429, {"message": "slow down"})
+        self.assertIsInstance(err, RateLimitError)
+        self.assertIsNone(err.retry_after_ms)
+
+    def test_maps_5xx_to_server_error(self) -> None:
+        for status in (500, 502, 503):
+            err = parse_http_error(status, {"message": "boom"})
+            self.assertIsInstance(err, ServerError)
+            self.assertEqual(err.status_code, status)
+            self.assertTrue(err.retryable)
+
+    def test_unknown_status_falls_back_to_base_error(self) -> None:
+        err = parse_http_error(418, {"message": "teapot"})
+        self.assertIs(type(err), BridgeError)
+        self.assertEqual(str(err), "teapot")
+        self.assertFalse(err.retryable)
+
+    def test_falls_back_to_default_message_when_missing(self) -> None:
+        err = parse_http_error(500, {})
+        self.assertEqual(str(err), "Request failed with status 500")
+
+    def test_network_error_is_retryable(self) -> None:
+        err = NetworkError("connection reset")
+        self.assertTrue(err.retryable)
+        self.assertEqual(str(err), "connection reset")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/rust/src/client.rs
+++ b/examples/rust/src/client.rs
@@ -60,10 +60,16 @@ impl BridgeClient {
         }
         let resp = req.send().await?;
         let status = resp.status().as_u16();
-        let value: Value = resp.json().await?;
+        let text = resp.text().await?;
         if (200..300).contains(&status) {
-            Ok(value)
+            Ok(serde_json::from_str(&text)?)
         } else {
+            // Non-2xx bodies aren't guaranteed to be JSON (proxies/gateways may
+            // return HTML or plain text) — fall back to the raw text as the
+            // error message instead of letting a parse failure mask the real
+            // HTTP status.
+            let value: Value =
+                serde_json::from_str(&text).unwrap_or_else(|_| json!({ "message": text }));
             Err(BridgeError::from_response(status, &value))
         }
     }

--- a/examples/rust/src/error.rs
+++ b/examples/rust/src/error.rs
@@ -37,3 +37,87 @@ impl BridgeError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn maps_401_and_403_to_auth() {
+        for status in [401u16, 403u16] {
+            let err = BridgeError::from_response(status, &json!({ "message": "nope" }));
+            match err {
+                BridgeError::Auth { status: s, message } => {
+                    assert_eq!(s, status);
+                    assert_eq!(message, "nope");
+                }
+                other => panic!("expected Auth, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn maps_400_and_422_to_validation() {
+        for status in [400u16, 422u16] {
+            let err = BridgeError::from_response(status, &json!({ "message": "bad input" }));
+            match err {
+                BridgeError::Validation { status: s, message } => {
+                    assert_eq!(s, status);
+                    assert_eq!(message, "bad input");
+                }
+                other => panic!("expected Validation, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn maps_404_to_not_found() {
+        let err = BridgeError::from_response(404, &json!({ "message": "missing" }));
+        assert!(matches!(err, BridgeError::NotFound { message } if message == "missing"));
+    }
+
+    #[test]
+    fn maps_429_to_rate_limit() {
+        let err = BridgeError::from_response(429, &json!({ "message": "slow down" }));
+        assert!(matches!(err, BridgeError::RateLimit { message } if message == "slow down"));
+    }
+
+    #[test]
+    fn maps_5xx_to_server() {
+        for status in [500u16, 502u16, 599u16] {
+            let err = BridgeError::from_response(status, &json!({ "message": "boom" }));
+            match err {
+                BridgeError::Server { status: s, message } => {
+                    assert_eq!(s, status);
+                    assert_eq!(message, "boom");
+                }
+                other => panic!("expected Server, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn maps_unknown_status_to_other() {
+        let err = BridgeError::from_response(418, &json!({ "message": "teapot" }));
+        match err {
+            BridgeError::Other { status, message } => {
+                assert_eq!(status, 418);
+                assert_eq!(message, "teapot");
+            }
+            other => panic!("expected Other, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn falls_back_to_default_message_when_missing() {
+        let err = BridgeError::from_response(500, &json!({}));
+        assert!(matches!(err, BridgeError::Server { message, .. } if message == "request failed"));
+    }
+
+    #[test]
+    fn falls_back_to_default_message_when_body_is_not_an_object() {
+        let err = BridgeError::from_response(502, &json!("<html>Bad Gateway</html>"));
+        assert!(matches!(err, BridgeError::Server { message, .. } if message == "request failed"));
+    }
+}

--- a/scripts/deploy-api.sh
+++ b/scripts/deploy-api.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# deploy-api.sh — Ship the API application Docker image to a remote host over SSH.
+#
+# This is the counterpart to scripts/deploy.sh (which deploys the Soroban
+# smart contract, not the API app). This script does the actual work implied
+# by deploy.yml / rollback.yml: pull the freshly built image from GHCR onto
+# DEPLOY_HOST and run it as the API container, with a single-hop rollback to
+# whatever image was running before the last deploy.
+#
+# Usage:
+#   IMAGE_TAG=sha-abc123 bash scripts/deploy-api.sh
+#   bash scripts/deploy-api.sh --rollback
+#
+# Options:
+#   --rollback   redeploy the image that was running before the last deploy
+#                on this host, ignoring IMAGE_TAG
+#
+# Required env vars:
+#   DEPLOY_HOST   — SSH host to deploy to
+#   DEPLOY_USER   — SSH user
+#   DEPLOY_KEY    — SSH private key (PEM content, not a path)
+#   IMAGE_TAG     — Docker tag to deploy (not required with --rollback)
+#
+# Optional env vars:
+#   IMAGE_REPO       — full image repo, default ghcr.io/$GITHUB_REPOSITORY
+#   DEPLOY_PORT       — SSH port (default 22)
+#   CONTAINER_NAME    — Docker container name (default c-address-bridge-api)
+#   REMOTE_APP_DIR    — remote state directory (default /opt/c-address-bridge)
+#   REMOTE_ENV_FILE   — env file passed to `docker run --env-file` on the host
+#                       (default $REMOTE_APP_DIR/.env)
+#   HOST_PORT         — host port to publish (default 3001)
+#   CONTAINER_PORT    — container port the app listens on (default 3001)
+#   SSH_OPTS          — extra ssh/scp options
+
+set -euo pipefail
+
+ROLLBACK=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rollback) ROLLBACK=true; shift ;;
+    *) echo "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+DEPLOY_HOST="${DEPLOY_HOST:?DEPLOY_HOST is required}"
+DEPLOY_USER="${DEPLOY_USER:?DEPLOY_USER is required}"
+DEPLOY_KEY="${DEPLOY_KEY:?DEPLOY_KEY is required}"
+DEPLOY_PORT="${DEPLOY_PORT:-22}"
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/${GITHUB_REPOSITORY:-}}"
+CONTAINER_NAME="${CONTAINER_NAME:-c-address-bridge-api}"
+REMOTE_APP_DIR="${REMOTE_APP_DIR:-/opt/c-address-bridge}"
+REMOTE_ENV_FILE="${REMOTE_ENV_FILE:-${REMOTE_APP_DIR}/.env}"
+HOST_PORT="${HOST_PORT:-3001}"
+CONTAINER_PORT="${CONTAINER_PORT:-3001}"
+SSH_OPTS="${SSH_OPTS:--o StrictHostKeyChecking=accept-new -o ConnectTimeout=10}"
+
+log()  { echo "[$(date -u +%H:%M:%SZ)] $*"; }
+warn() { echo "[$(date -u +%H:%M:%SZ)] WARN: $*" >&2; }
+err()  { echo "[$(date -u +%H:%M:%SZ)] ERROR: $*" >&2; exit 1; }
+
+KEY_FILE="$(mktemp)"
+cleanup() { rm -f "$KEY_FILE"; }
+trap cleanup EXIT
+
+printf '%s\n' "$DEPLOY_KEY" > "$KEY_FILE"
+chmod 600 "$KEY_FILE"
+
+# shellcheck disable=SC2086
+ssh_run() {
+  ssh $SSH_OPTS -p "$DEPLOY_PORT" -i "$KEY_FILE" "${DEPLOY_USER}@${DEPLOY_HOST}" "$@"
+}
+
+# Runs the given image as $CONTAINER_NAME on the remote host, recording the
+# previously-running image (if any) to REMOTE_APP_DIR/previous-image.txt so a
+# later --rollback can put it back.
+remote_run_image() {
+  local image="$1"
+  ssh_run bash -s <<REMOTE_SCRIPT
+set -euo pipefail
+mkdir -p "${REMOTE_APP_DIR}"
+touch "${REMOTE_ENV_FILE}"
+
+echo "Pulling ${image}..."
+docker pull "${image}"
+
+if docker inspect "${CONTAINER_NAME}" >/dev/null 2>&1; then
+  CURRENT_IMAGE=\$(docker inspect --format '{{.Config.Image}}' "${CONTAINER_NAME}")
+  if [[ "\$CURRENT_IMAGE" != "${image}" ]]; then
+    echo "\$CURRENT_IMAGE" > "${REMOTE_APP_DIR}/previous-image.txt"
+  fi
+  echo "Stopping existing container ${CONTAINER_NAME}..."
+  docker stop "${CONTAINER_NAME}" >/dev/null
+  docker rm "${CONTAINER_NAME}" >/dev/null
+fi
+
+echo "Starting ${CONTAINER_NAME} from ${image}..."
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --restart unless-stopped \
+  -p "${HOST_PORT}:${CONTAINER_PORT}" \
+  --env-file "${REMOTE_ENV_FILE}" \
+  "${image}"
+
+echo "${image}" > "${REMOTE_APP_DIR}/current-image.txt"
+
+echo "Waiting for container to become healthy..."
+for i in \$(seq 1 30); do
+  if curl -sf "http://localhost:${HOST_PORT}/health" >/dev/null 2>&1; then
+    echo "Container is healthy."
+    exit 0
+  fi
+  sleep 2
+done
+echo "Container did not become healthy in time." >&2
+exit 1
+REMOTE_SCRIPT
+}
+
+deploy() {
+  local image_tag="${IMAGE_TAG:?IMAGE_TAG is required}"
+  [[ -n "$IMAGE_REPO" ]] || err "IMAGE_REPO is required (or set GITHUB_REPOSITORY)"
+  local image="${IMAGE_REPO}:${image_tag}"
+
+  log "Deploying ${image} to ${DEPLOY_HOST}:${DEPLOY_PORT} as ${CONTAINER_NAME}..."
+  remote_run_image "$image"
+  log "Deployment complete. DEPLOYED_IMAGE=${image}"
+}
+
+rollback() {
+  log "Rolling back ${CONTAINER_NAME} on ${DEPLOY_HOST}..."
+  local prev_image
+  prev_image=$(ssh_run "cat '${REMOTE_APP_DIR}/previous-image.txt' 2>/dev/null" || true)
+  [[ -n "$prev_image" ]] || err "No previous image recorded on ${DEPLOY_HOST}. Manual rollback required."
+
+  log "Redeploying previous image: ${prev_image}"
+  remote_run_image "$prev_image"
+  log "Rollback complete. DEPLOYED_IMAGE=${prev_image}"
+}
+
+if $ROLLBACK; then
+  rollback
+else
+  deploy
+fi


### PR DESCRIPTION
## Summary
- **#293** — `examples/rust`'s `request()` parsed the response body as JSON before checking HTTP status, so non-2xx responses with non-JSON bodies (proxy/gateway HTML, plain text) surfaced as a generic parse error instead of `BridgeError::from_response`. Now reads the body once, checks status, then falls back to the raw text as the error message if it isn't valid JSON.
- **#294** — Added unit tests for the client-side HTTP error-mapping logic in all four example clients: Rust (`BridgeError::from_response`), Go (`request()` via `httptest`), Java (`BridgeException.fromResponse`, with JUnit 5 wired into `pom.xml`), and Python (`parse_http_error`, stdlib `unittest`, no new dependency).
- **#295** — Added `scripts/deploy-api.sh`, which actually ships the built API Docker image to a host over SSH using `DEPLOY_HOST`/`DEPLOY_USER`/`DEPLOY_KEY`/`IMAGE_TAG`. `deploy.yml`/`rollback.yml` previously passed these variables to `scripts/deploy.sh`, which only builds/deploys the Soroban contract and silently ignored them — the API app was never actually deployed.
- **#296** — Wired `scripts/blue-green-deploy.sh` into `deploy.yml` (staging/production) and `rollback.yml`, using `deploy-api.sh` as the per-color deploy command, with blue/green state persisted across runs via `actions/cache`. Dev keeps a fast single-target deploy. Updated the README's stale blue-green example and documented the new required secrets/variables.

## Test plan
- [ ] `cargo test` in `examples/rust` (new `error.rs` unit tests)
- [ ] `go test ./...` in `examples/go`
- [ ] `mvn test` in `examples/java`
- [ ] `python -m unittest discover -s tests` in `examples/python`
- [ ] Review `deploy.yml`/`rollback.yml` changes against actual deploy infra before first live run (new required secrets: `BLUE_DEPLOY_HOST`, `GREEN_DEPLOY_HOST`; new vars: `BLUE_APP_URL`, `GREEN_APP_URL`, `SWITCH_TRAFFIC_COMMAND` — documented in README)

Closes #293 
Closes #294 
Closes #295 
Closes #296 