### PR TITLE
Fix/proposal storage tier cap admin rotation sdk fuzz

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -61,6 +61,10 @@ use soroban_sdk::{
 
 const TTL_THRESHOLD: u32 = 5000;
 const TTL_EXTEND: u32 = 50000;
+/// Maximum number of rebate tiers an admin may register. `rebate_bps` scans
+/// every tier on each funding call, so this bounds that cost regardless of
+/// how many `set_rebate_tier` calls have ever been made.
+const MAX_TIERS: u32 = 50;
 
 const ERR_INVALID_C_ADDRESS: &str = "invalid c-address: not a contract address";
 const ERR_REENTRANT_CALL: &str = "reentrant call detected";
@@ -68,6 +72,7 @@ const ERR_EMPTY_BATCH: &str = "batch inputs must not be empty";
 const ERR_MISMATCHED_LENGTHS: &str = "batch input vectors must have same length";
 const ERR_NO_ENTRIES_TO_ARCHIVE: &str = "no entries to archive";
 const ERR_ADMIN_CANNOT_BE_CONTRACT: &str = "admin address cannot be the contract address";
+const ERR_TIER_CAP_EXCEEDED: &str = "tier count exceeds maximum allowed";
 
 /// Storage keys used throughout the contract.
 ///
@@ -465,6 +470,7 @@ impl OnboardingBridge {
             .expect("not initialized");
         admins.get_unchecked(0).require_auth();
         assert!(discount_bps <= 5000, "discount capped at 50%");
+        assert!(tier_index < MAX_TIERS, "{}", ERR_TIER_CAP_EXCEEDED);
         env.storage()
             .instance()
             .set(&DataKey::TierThreshold(tier_index), &threshold);

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -135,6 +135,12 @@ pub enum ProposalAction {
     WithdrawFees(Address, Address, i128),
     Pause,
     Unpause,
+    /// Replaces the entire admin set. The current threshold must still be
+    /// satisfiable by the new admin count, or execution panics.
+    RotateAdmins(Vec<Address>),
+    /// Changes the multisig approval threshold. Must be > 0 and <= the
+    /// current admin count.
+    SetThreshold(u32),
 }
 
 #[contracttype]
@@ -993,6 +999,45 @@ impl OnboardingBridge {
             ProposalAction::Unpause => {
                 env.storage().instance().set(&DataKey::Paused, &false);
                 env.events().publish((Symbol::new(&env, "unpaused"),), ());
+                0i128
+            }
+            ProposalAction::RotateAdmins(new_admins) => {
+                assert!(!new_admins.is_empty(), "admins must not be empty");
+                Self::validate_admins(&env, &new_admins);
+                let threshold: u32 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Threshold)
+                    .expect("not initialized");
+                assert!(
+                    threshold <= new_admins.len(),
+                    "threshold exceeds admin count"
+                );
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Admins, &new_admins);
+                env.events().publish(
+                    (Symbol::new(&env, "admins_rotated"),),
+                    (new_admins.clone(),),
+                );
+                0i128
+            }
+            ProposalAction::SetThreshold(new_threshold) => {
+                let admins: Vec<Address> = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::Admins)
+                    .expect("not initialized");
+                assert!(new_threshold > 0, "threshold must be > 0");
+                assert!(
+                    new_threshold <= admins.len(),
+                    "threshold exceeds admin count"
+                );
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Threshold, &new_threshold);
+                env.events()
+                    .publish((Symbol::new(&env, "threshold_set"),), (new_threshold,));
                 0i128
             }
         };

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -95,6 +95,7 @@ pub enum DataKey {
     ProposalNonce,
     Proposal(u32),
     ProposalApproval(u32, Address),
+    NextPruneId,
     ReentrancyGuard,
     Funding(u32),
     FundingCount,
@@ -298,6 +299,7 @@ impl OnboardingBridge {
         env.storage().instance().set(&DataKey::NextArchiveId, &0u32);
         env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::ProposalNonce, &0u32);
+        env.storage().instance().set(&DataKey::NextPruneId, &1u32);
         env.storage()
             .instance()
             .set(&DataKey::MinAmount, &min_amount);
@@ -1030,6 +1032,87 @@ impl OnboardingBridge {
         }
 
         active
+    }
+
+    /// Removes executed or expired proposals — and their per-admin approval
+    /// flags — from instance storage.
+    ///
+    /// `propose`/`approve` write `DataKey::Proposal`/`DataKey::ProposalApproval`
+    /// into instance storage and previously nothing ever removed them, so the
+    /// contract's instance footprint grew forever with governance activity.
+    /// This sweeps forward from the last pruned id, scanning at most
+    /// `max_scan` proposals, stopping early if it reaches a proposal that is
+    /// still active (neither executed nor expired) so a later call can pick
+    /// up from there once it becomes terminal. Returns the number of
+    /// proposals actually pruned.
+    pub fn prune_proposals(env: Env, max_scan: u32) -> u32 {
+        let admins: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admins)
+            .expect("not initialized");
+        if !admins.is_empty() {
+            admins.get_unchecked(0).require_auth();
+        }
+        Self::extend_ttl(&env);
+
+        let nonce: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalNonce)
+            .unwrap_or(0);
+        let mut cursor: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextPruneId)
+            .unwrap_or(1);
+        let current_block = env.ledger().sequence();
+
+        let mut pruned: u32 = 0;
+        let mut scanned: u32 = 0;
+
+        while cursor <= nonce && scanned < max_scan {
+            match env
+                .storage()
+                .instance()
+                .get::<DataKey, Proposal>(&DataKey::Proposal(cursor))
+            {
+                Some(proposal) => {
+                    if proposal.executed || current_block > proposal.expiry {
+                        env.storage().instance().remove(&DataKey::Proposal(cursor));
+                        for i in 0..admins.len() {
+                            let approval_key =
+                                DataKey::ProposalApproval(cursor, admins.get_unchecked(i));
+                            env.storage().instance().remove(&approval_key);
+                        }
+                        // The proposer always has an approval flag from
+                        // `propose`, even if no longer an admin by the time
+                        // this runs — clear it explicitly so it can't linger.
+                        env.storage()
+                            .instance()
+                            .remove(&DataKey::ProposalApproval(cursor, proposal.proposer));
+                        pruned += 1;
+                        cursor += 1;
+                    } else {
+                        // Still active: stop advancing so a future call
+                        // resumes here instead of skipping it permanently.
+                        break;
+                    }
+                }
+                None => {
+                    // Already pruned in a previous call — keep advancing.
+                    cursor += 1;
+                }
+            }
+            scanned += 1;
+        }
+
+        env.storage().instance().set(&DataKey::NextPruneId, &cursor);
+
+        env.events()
+            .publish((Symbol::new(&env, "proposals_pruned"),), (pruned, cursor));
+
+        pruned
     }
 }
 

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1000,6 +1000,141 @@ fn test_get_active_proposals() {
     assert_eq!(active.get_unchecked(0).id, pid3);
 }
 
+// ===========================================================================
+// Proposal storage pruning tests
+// ===========================================================================
+
+/// Instance storage can only be inspected from within the contract's own
+/// execution context, so tests that peek at raw `DataKey` presence wrap the
+/// check with `env.as_contract(&bridge_address, ...)`.
+fn proposal_exists(env: &Env, bridge_address: &Address, id: u32) -> bool {
+    env.as_contract(bridge_address, || {
+        env.storage().instance().has(&DataKey::Proposal(id))
+    })
+}
+
+fn approval_exists(env: &Env, bridge_address: &Address, id: u32, admin: &Address) -> bool {
+    env.as_contract(bridge_address, || {
+        env.storage()
+            .instance()
+            .has(&DataKey::ProposalApproval(id, admin.clone()))
+    })
+}
+
+#[test]
+fn test_prune_proposals_removes_executed_and_expired() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let proposer = admins.get_unchecked(0);
+    let approver = admins.get_unchecked(1);
+
+    let pid1 = bridge.propose(&proposer, &ProposalAction::SetFee(200), &1000);
+    bridge.approve(&approver, &pid1);
+    bridge.execute(&pid1);
+
+    let pid2 = bridge.propose(&proposer, &ProposalAction::SetFee(300), &10);
+    env.ledger()
+        .set_sequence_number(env.ledger().sequence() + 20);
+
+    assert!(proposal_exists(&env, &bridge.address, pid1));
+    assert!(proposal_exists(&env, &bridge.address, pid2));
+
+    let pruned = bridge.prune_proposals(&10);
+    assert_eq!(pruned, 2);
+
+    assert!(!proposal_exists(&env, &bridge.address, pid1));
+    assert!(!proposal_exists(&env, &bridge.address, pid2));
+    assert!(!approval_exists(&env, &bridge.address, pid1, &proposer));
+    assert!(!approval_exists(&env, &bridge.address, pid1, &approver));
+    assert!(!approval_exists(&env, &bridge.address, pid2, &proposer));
+}
+
+#[test]
+fn test_prune_proposals_stops_at_still_active_proposal() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let proposer = admins.get_unchecked(0);
+    let approver = admins.get_unchecked(1);
+
+    let pid1 = bridge.propose(&proposer, &ProposalAction::SetFee(200), &1000);
+    bridge.approve(&approver, &pid1);
+    bridge.execute(&pid1);
+
+    // pid2 is neither executed nor expired — pruning must not skip past it.
+    let pid2 = bridge.propose(&proposer, &ProposalAction::SetFee(300), &1000);
+
+    let pruned = bridge.prune_proposals(&10);
+    assert_eq!(pruned, 1);
+    assert!(!proposal_exists(&env, &bridge.address, pid1));
+    assert!(proposal_exists(&env, &bridge.address, pid2));
+
+    // Once pid2 becomes terminal, a later prune call must still reach it.
+    bridge.approve(&approver, &pid2);
+    bridge.execute(&pid2);
+    let pruned2 = bridge.prune_proposals(&10);
+    assert_eq!(pruned2, 1);
+    assert!(!proposal_exists(&env, &bridge.address, pid2));
+}
+
+#[test]
+fn test_prune_proposals_respects_max_scan() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let proposer = admins.get_unchecked(0);
+    let approver = admins.get_unchecked(1);
+
+    let mut ids: std::vec::Vec<u32> = std::vec::Vec::new();
+    for _ in 0..5 {
+        let pid = bridge.propose(&proposer, &ProposalAction::SetFee(50), &1000);
+        bridge.approve(&approver, &pid);
+        bridge.execute(&pid);
+        ids.push(pid);
+    }
+
+    // Only scan/prune 2 at a time.
+    let pruned = bridge.prune_proposals(&2);
+    assert_eq!(pruned, 2);
+    assert!(!proposal_exists(&env, &bridge.address, ids[0]));
+    assert!(!proposal_exists(&env, &bridge.address, ids[1]));
+    assert!(proposal_exists(&env, &bridge.address, ids[2]));
+
+    let pruned = bridge.prune_proposals(&2);
+    assert_eq!(pruned, 2);
+    assert!(!proposal_exists(&env, &bridge.address, ids[2]));
+    assert!(!proposal_exists(&env, &bridge.address, ids[3]));
+    assert!(proposal_exists(&env, &bridge.address, ids[4]));
+
+    let pruned = bridge.prune_proposals(&2);
+    assert_eq!(pruned, 1);
+    assert!(!proposal_exists(&env, &bridge.address, ids[4]));
+}
+
+/// Guards against the instance-storage-growth regression: however many
+/// propose/approve/execute cycles run, pruning after each one keeps the
+/// resident (non-removed) proposal count at zero rather than accumulating.
+#[test]
+fn test_instance_storage_does_not_grow_unboundedly_with_proposal_cycles() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let proposer = admins.get_unchecked(0);
+    let approver = admins.get_unchecked(1);
+
+    const CYCLES: u32 = 200;
+    for _ in 0..CYCLES {
+        let pid = bridge.propose(&proposer, &ProposalAction::SetFee(50), &1000);
+        bridge.approve(&approver, &pid);
+        bridge.execute(&pid);
+
+        let pruned = bridge.prune_proposals(&10);
+        assert_eq!(pruned, 1);
+
+        assert!(!proposal_exists(&env, &bridge.address, pid));
+        assert!(!approval_exists(&env, &bridge.address, pid, &proposer));
+        assert!(!approval_exists(&env, &bridge.address, pid, &approver));
+    }
+
+    assert_eq!(bridge.get_active_proposals().len(), 0);
+    for id in 1..=CYCLES {
+        assert!(!proposal_exists(&env, &bridge.address, id));
+    }
+}
+
 #[test]
 fn test_proposal_withdraw_fees_execution() {
     let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1696,6 +1696,56 @@ fn test_set_rebate_tier_rejects_discount_above_cap() {
     bridge.set_rebate_tier(&0, &1000i128, &5001); // > 5000 bps (50%)
 }
 
+// ===========================================================================
+// Rebate tier count cap tests
+// ===========================================================================
+
+#[test]
+fn test_set_rebate_tier_accepts_up_to_cap() {
+    let (_env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
+    // MAX_TIERS is 50, so indices 0..=49 must all be accepted.
+    for i in 0..50u32 {
+        bridge.set_rebate_tier(&i, &(i as i128 * 100), &10);
+    }
+}
+
+#[test]
+#[should_panic(expected = "tier count exceeds maximum allowed")]
+fn test_set_rebate_tier_rejects_beyond_cap() {
+    let (_env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
+    bridge.set_rebate_tier(&50, &1000i128, &10); // index 50 is the 51st tier, beyond MAX_TIERS
+}
+
+#[test]
+#[should_panic(expected = "tier count exceeds maximum allowed")]
+fn test_set_rebate_tier_rejects_far_beyond_cap() {
+    let (_env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
+    bridge.set_rebate_tier(&10_000, &1000i128, &10);
+}
+
+#[test]
+fn test_set_rebate_tier_update_within_cap_still_allowed() {
+    let (env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);
+    bridge.set_rebate_tier(&0, &1000i128, &100);
+    // Re-registering an existing (in-range) tier index must not be blocked
+    // by the cap check even after many updates.
+    for _ in 0..5 {
+        bridge.set_rebate_tier(&0, &1000i128, &200);
+    }
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let token_addr = register_test_token(&env);
+    TestTokenClient::new(&env, &token_addr).mint(&user, &5000);
+    bridge.fund_c_address(
+        &user,
+        &target,
+        &token_addr,
+        &2000,
+        &String::from_str(&env, "tier"),
+    );
+    assert_eq!(bridge.rebate_for(&user), 200);
+}
+
 #[test]
 fn test_user_volume_tracks_funding() {
     let (env, bridge, _admins) = setup_env_with_admins(1, 1, 100, 1000);

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1206,6 +1206,198 @@ fn test_proposal_withdraw_excessive_fees_rejected() {
 }
 
 // ===========================================================================
+// Governed admin rotation / threshold change tests
+// ===========================================================================
+
+#[test]
+fn test_rotate_admins_happy_path() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let new_admin = Address::generate(&env);
+    let mut new_admins: Vec<Address> = Vec::new(&env);
+    new_admins.push_back(admins.get_unchecked(0));
+    new_admins.push_back(new_admin.clone());
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(new_admins.clone()),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+
+    let stored = bridge.get_admins();
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get_unchecked(0), admins.get_unchecked(0));
+    assert_eq!(stored.get_unchecked(1), new_admin);
+
+    // The removed admin can no longer propose/approve.
+    assert!(!bridge.is_paused());
+}
+
+#[test]
+#[should_panic(expected = "only admins can propose")]
+fn test_rotate_admins_removes_old_admin_privileges() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let removed_admin = admins.get_unchecked(1);
+    let mut new_admins: Vec<Address> = Vec::new(&env);
+    new_admins.push_back(admins.get_unchecked(0));
+    new_admins.push_back(Address::generate(&env));
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(new_admins),
+        &1000,
+    );
+    bridge.approve(&removed_admin, &pid);
+    bridge.execute(&pid);
+
+    // removed_admin is no longer in the admin set — must be rejected.
+    bridge.propose(&removed_admin, &ProposalAction::SetFee(1), &1000);
+}
+
+#[test]
+fn test_rotate_admins_new_admin_can_govern() {
+    let (env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+    let new_admin = Address::generate(&env);
+    let mut new_admins: Vec<Address> = Vec::new(&env);
+    new_admins.push_back(admins.get_unchecked(0));
+    new_admins.push_back(new_admin.clone());
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(new_admins),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+
+    // The newly added admin can now propose/approve/execute.
+    let pid2 = bridge.propose(&new_admin, &ProposalAction::SetFee(250), &1000);
+    bridge.approve(&admins.get_unchecked(0), &pid2);
+    bridge.execute(&pid2);
+    assert_eq!(bridge.fee_bps(), 250);
+}
+
+#[test]
+#[should_panic(expected = "threshold exceeds admin count")]
+fn test_rotate_admins_rejects_below_current_threshold() {
+    let (env, bridge, admins) = setup_env_with_admins(3, 3, 100, 1000);
+    // Threshold is 3, but the new admin set only has 2 members.
+    let mut new_admins: Vec<Address> = Vec::new(&env);
+    new_admins.push_back(admins.get_unchecked(0));
+    new_admins.push_back(admins.get_unchecked(1));
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(new_admins),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.approve(&admins.get_unchecked(2), &pid);
+    bridge.execute(&pid);
+}
+
+#[test]
+#[should_panic(expected = "admins must not be empty")]
+fn test_rotate_admins_rejects_empty() {
+    let (env, bridge, admins) = setup_env_with_admins(1, 1, 100, 1000);
+    let empty: Vec<Address> = Vec::new(&env);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(empty),
+        &1000,
+    );
+    bridge.execute(&pid);
+}
+
+#[test]
+#[should_panic(expected = "admin address cannot be the contract address")]
+fn test_rotate_admins_rejects_contract_address_as_admin() {
+    let (env, bridge, admins) = setup_env_with_admins(1, 1, 100, 1000);
+    let bridge_address = bridge.address.clone();
+    let mut new_admins: Vec<Address> = Vec::new(&env);
+    new_admins.push_back(bridge_address);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::RotateAdmins(new_admins),
+        &1000,
+    );
+    bridge.execute(&pid);
+}
+
+#[test]
+fn test_set_threshold_happy_path() {
+    let (_env, bridge, admins) = setup_env_with_admins(3, 2, 100, 1000);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::SetThreshold(3),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+
+    assert_eq!(bridge.get_threshold(), 3);
+}
+
+#[test]
+#[should_panic(expected = "threshold must be > 0")]
+fn test_set_threshold_rejects_zero() {
+    let (_env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::SetThreshold(0),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+}
+
+#[test]
+#[should_panic(expected = "threshold exceeds admin count")]
+fn test_set_threshold_rejects_above_admin_count() {
+    let (_env, bridge, admins) = setup_env_with_admins(2, 2, 100, 1000);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::SetThreshold(3),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+}
+
+/// Edge case: lowering the threshold below an already-accrued approval count
+/// on a separate, still-pending proposal must not corrupt state — that
+/// proposal simply becomes immediately executable under the new threshold.
+#[test]
+fn test_set_threshold_below_active_proposal_approval_count() {
+    let (_env, bridge, admins) = setup_env_with_admins(3, 3, 100, 1000);
+    let proposer = admins.get_unchecked(0);
+
+    // fee-change proposal accrues 2 approvals under the original threshold of 3.
+    let fee_pid = bridge.propose(&proposer, &ProposalAction::SetFee(400), &1000);
+    bridge.approve(&admins.get_unchecked(1), &fee_pid);
+    assert_eq!(bridge.get_proposal(&fee_pid).approval_count, 2);
+
+    // Separately, lower the threshold to 2 (itself reaching the 3-approval
+    // threshold first).
+    let threshold_pid = bridge.propose(&proposer, &ProposalAction::SetThreshold(2), &1000);
+    bridge.approve(&admins.get_unchecked(1), &threshold_pid);
+    bridge.approve(&admins.get_unchecked(2), &threshold_pid);
+    bridge.execute(&threshold_pid);
+    assert_eq!(bridge.get_threshold(), 2);
+
+    // fee_pid already had 2 approvals, which now meets the new threshold —
+    // it must be executable without requiring a fresh approval.
+    bridge.execute(&fee_pid);
+    assert_eq!(bridge.fee_bps(), 400);
+}
+
+// ===========================================================================
 // Original behavior tests (adapted for multisig)
 // ===========================================================================
 

--- a/sdk/tests/fuzz.test.ts
+++ b/sdk/tests/fuzz.test.ts
@@ -1,74 +1,112 @@
 import { test, expect } from 'vitest';
 import fc from 'fast-check';
-import { OnboardingClient } from '../src/client';
-import { formatAmount, calculateFee, validateAddress, constructUrl } from '../src/utils';
+import {
+  isValidStellarAddress,
+  isCAddress,
+  isGAddress,
+  isValidTokenIdentifier,
+  isSacTokenAddress,
+  validateSacTokenAddress,
+  formatStellarAmount,
+  tokenFromLegacy,
+  getDefaultDecimals,
+} from '../src/utils';
 
-test('Fuzz testing formatAmount', () => {
+test('Fuzz testing isValidStellarAddress never throws and is consistent with isCAddress/isGAddress', () => {
+  fc.assert(
+    fc.property(fc.string({ maxLength: 200 }), (address) => {
+      const valid = isValidStellarAddress(address);
+      expect(typeof valid).toBe('boolean');
+      if (isCAddress(address) || isGAddress(address)) {
+        expect(valid).toBe(true);
+      }
+      if (valid) {
+        expect(isCAddress(address) || isGAddress(address)).toBe(true);
+      }
+    }),
+    { numRuns: 1000 },
+  );
+});
+
+test('Fuzz testing isSacTokenAddress / validateSacTokenAddress agree', () => {
+  fc.assert(
+    fc.property(fc.string({ maxLength: 200 }), (address) => {
+      const valid = isSacTokenAddress(address);
+      expect(typeof valid).toBe('boolean');
+      if (valid) {
+        expect(() => validateSacTokenAddress(address)).not.toThrow();
+      } else {
+        expect(() => validateSacTokenAddress(address)).toThrow();
+      }
+    }),
+    { numRuns: 1000 },
+  );
+});
+
+test('Fuzz testing isValidTokenIdentifier never throws', () => {
+  fc.assert(
+    fc.property(fc.string({ maxLength: 200 }), (identifier) => {
+      const result = isValidTokenIdentifier(identifier);
+      expect(typeof result).toBe('boolean');
+      if (identifier !== 'native' && result) {
+        expect(isSacTokenAddress(identifier)).toBe(true);
+      }
+    }),
+    { numRuns: 1000 },
+  );
+});
+
+test('Fuzz testing formatStellarAmount never throws and always returns a decimal string', () => {
   fc.assert(
     fc.property(
-      fc.oneof(fc.integer(), fc.float(), fc.maxSafeInteger(), fc.double(), fc.string(), fc.constant(NaN), fc.constant(Infinity), fc.constant(-Infinity)),
+      fc.oneof(
+        fc.stringMatching(/^[0-9]{1,30}$/),
+        fc.constant(''),
+        fc.constant('0'),
+      ),
       (amount) => {
-        try {
-          const result = formatAmount(amount as any);
-          expect(typeof result).toBe('string');
-        } catch (e) {
-          // Expect standard error objects, no crashes
-          expect(e).toBeInstanceOf(Error);
-        }
-      }
+        const result = formatStellarAmount(amount);
+        expect(typeof result).toBe('string');
+        expect(result).toContain('.');
+        expect(result.split('.')[1]).toHaveLength(7);
+      },
     ),
-    { numRuns: 1000 }
+    { numRuns: 1000 },
   );
 });
 
-test('Fuzz testing calculateFee', () => {
+test('Fuzz testing tokenFromLegacy never throws and always returns a well-formed Token', () => {
   fc.assert(
     fc.property(
-      fc.double({ noNaN: false, noDefaultInfinity: false }), 
-      fc.double({ noNaN: false, noDefaultInfinity: false }),
-      (amount, rate) => {
-        try {
-          const fee = calculateFee(amount, rate);
-          expect(typeof fee).toBe('number');
-        } catch (e) {
-          expect(e).toBeInstanceOf(Error);
+      fc.option(fc.string({ maxLength: 100 }), { nil: undefined }),
+      fc.option(fc.string({ maxLength: 100 }), { nil: undefined }),
+      (tokenAddress, sourceAsset) => {
+        const token = tokenFromLegacy(tokenAddress, sourceAsset);
+        expect(token.type === 'native' || token.type === 'sac').toBe(true);
+        if (token.type === 'sac') {
+          expect(isSacTokenAddress(token.contractId)).toBe(true);
         }
-      }
+        // Result must always be usable by getDefaultDecimals without throwing.
+        expect(typeof getDefaultDecimals(token)).toBe('number');
+      },
     ),
-    { numRuns: 1000 }
+    { numRuns: 1000 },
   );
 });
 
-test('Fuzz testing validateAddress', () => {
+test('Fuzz testing getDefaultDecimals returns a stable positive integer for both token types', () => {
   fc.assert(
     fc.property(
-      fc.string({ maxLength: 1000 }),
-      (address) => {
-        try {
-          const isValid = validateAddress(address);
-          expect(typeof isValid).toBe('boolean');
-        } catch (e) {
-          expect(e).toBeInstanceOf(Error);
-        }
-      }
+      fc.oneof(
+        fc.constant({ type: 'native' as const }),
+        fc.string({ maxLength: 100 }).map((contractId) => ({ type: 'sac' as const, contractId })),
+      ),
+      (token) => {
+        const decimals = getDefaultDecimals(token);
+        expect(Number.isInteger(decimals)).toBe(true);
+        expect(decimals).toBeGreaterThan(0);
+      },
     ),
-    { numRuns: 1000 }
-  );
-});
-
-test('Fuzz testing constructUrl', () => {
-  fc.assert(
-    fc.property(
-      fc.string(), fc.dictionary(fc.string(), fc.string()),
-      (baseUrl, params) => {
-        try {
-          const url = constructUrl(baseUrl, params);
-          expect(typeof url).toBe('string');
-        } catch (e) {
-          expect(e).toBeInstanceOf(Error);
-        }
-      }
-    ),
-    { numRuns: 1000 }
+    { numRuns: 1000 },
   );
 });


### PR DESCRIPTION
Closes #249 
Closes #250 
Closes #251 
Closes #252 

Summary:

1. fix(contract): prune executed/expired proposals from instance storage — Added prune_proposals(max_scan), a first-admin-gated sweep that removes Proposal/ProposalApproval entries once a proposal is executed or past expiry, tracking progress via a new NextPruneId cursor so calls can be paginated and resumed. Added tests including a 200-cycle propose/approve/execute/prune loop proving no proposal entries accumulate.
2. fix(contract): cap rebate tier count in set_rebate_tier — Added a MAX_TIERS = 50 cap so rebate_bps's per-call tier scan (used by every funding call) can't grow unboundedly. Updates to already-registered in-range tiers still work.
3. feat(contract): add governed admin rotation and threshold change — Added ProposalAction::RotateAdmins and ProposalAction::SetThreshold, letting the existing multisig replace the admin set or change the approval threshold without a redeploy. Covered the happy paths plus edge cases (shrinking below current threshold, removed-admin privilege loss, and lowering threshold below an already-accrued approval count on a separate pending proposal).
4. fix(sdk): rewrite fuzz.test.ts against real SDK exports — The file imported a nonexistent src/client.ts and functions that don't exist in utils.ts, breaking npm test at module resolution. Rewrote it to fuzz the SDK's actual address/token helpers.