### PR TITLE
Fix/archive hash storage usage fee sync and fee token tests

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -732,7 +732,7 @@ impl OnboardingBridge {
         let archive_count = if count > total { total } else { count };
         assert!(archive_count > 0, "{}", ERR_NO_ENTRIES_TO_ARCHIVE);
 
-        let mut buf: Vec<i128> = Vec::new(&env);
+        let mut hash_bytes = Bytes::new(&env);
         for i in 1..=archive_count {
             if let Some(mut record) = env
                 .storage()
@@ -740,8 +740,13 @@ impl OnboardingBridge {
                 .get::<DataKey, FundingRecord>(&DataKey::Funding(i))
             {
                 record.archived = true;
-                buf.push_back(record.amount);
-                buf.push_back(record.fee);
+                hash_bytes.append(&record.source.to_string().to_bytes());
+                hash_bytes.append(&record.target.to_string().to_bytes());
+                hash_bytes.append(&record.token_address.to_string().to_bytes());
+                hash_bytes.extend_from_array(&record.amount.to_be_bytes());
+                hash_bytes.extend_from_array(&record.fee.to_be_bytes());
+                hash_bytes.extend_from_array(&record.ledger.to_be_bytes());
+                hash_bytes.append(&record.memo.to_bytes());
                 env.storage()
                     .persistent()
                     .set(&DataKey::Funding(i), &record);
@@ -754,12 +759,6 @@ impl OnboardingBridge {
             .get(&DataKey::NextArchiveId)
             .unwrap_or(0);
 
-        let mut hash_bytes = Bytes::new(&env);
-        for i in 0..buf.len() {
-            let val = buf.get(i).unwrap();
-            let byte: u8 = (val & 0xFF) as u8;
-            hash_bytes.push_back(byte);
-        }
         let hash: Hash<32> = env.crypto().sha256(&hash_bytes);
         let hash_val: BytesN<32> = hash.to_bytes();
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -782,6 +782,10 @@ impl OnboardingBridge {
         hash_val
     }
 
+    /// Returns `(funding_count, archived_batch_count, accumulated_fees, hot_count)`
+    /// where `hot_count` is the number of funding records still in "hot"
+    /// (non-archived) persistent storage, derived by scanning each record's
+    /// `archived` flag.
     pub fn storage_usage(env: Env) -> (u32, u32, i128, u32) {
         let funding_count: u32 = env
             .storage()
@@ -798,7 +802,21 @@ impl OnboardingBridge {
             .instance()
             .get(&DataKey::AccumulatedFees)
             .unwrap_or(0);
-        (funding_count, archived_count, accumulated_fees, 5u32)
+
+        let mut hot_count: u32 = 0;
+        for i in 1..=funding_count {
+            if let Some(record) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, FundingRecord>(&DataKey::Funding(i))
+            {
+                if !record.archived {
+                    hot_count += 1;
+                }
+            }
+        }
+
+        (funding_count, archived_count, accumulated_fees, hot_count)
     }
 
     pub fn propose(env: Env, proposer: Address, action: ProposalAction, expiry_blocks: u32) -> u32 {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -947,6 +947,17 @@ impl OnboardingBridge {
                     .expect("not initialized");
                 assert!(new_fee_bps <= max_fee, "fee exceeds max_fee_bps");
                 env.storage().instance().set(&DataKey::FeeBps, &new_fee_bps);
+
+                let mut params: InitializationParams = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::InitializationParams)
+                    .expect("not initialized");
+                params.fee_bps = new_fee_bps;
+                env.storage()
+                    .instance()
+                    .set(&DataKey::InitializationParams, &params);
+
                 env.events()
                     .publish((Symbol::new(&env, "set_fee"),), (new_fee_bps,));
                 0i128

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1845,3 +1845,143 @@ fn test_fund_c_address_above_max_amount_panics() {
         &String::from_str(&env, "above max"),
     );
 }
+
+// ===========================================================================
+// Fee-token whitelist / rate coverage
+// ===========================================================================
+
+#[test]
+fn test_fee_token_whitelist_default_and_toggle() {
+    let (_env, bridge, token, admin) = full_setup(100);
+    assert!(!bridge.is_fee_token_whitelisted(&token));
+
+    let pid = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenWhitelist(token.clone(), true),
+        &1000,
+    );
+    bridge.execute(&pid);
+    assert!(bridge.is_fee_token_whitelisted(&token));
+
+    let pid2 = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenWhitelist(token.clone(), false),
+        &1000,
+    );
+    bridge.execute(&pid2);
+    assert!(!bridge.is_fee_token_whitelisted(&token));
+}
+
+#[test]
+fn test_fee_token_rate_default_and_set() {
+    let (_env, bridge, token, admin) = full_setup(100);
+    assert_eq!(bridge.fee_token_rate(&token), 10000);
+
+    let pid = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 5000),
+        &1000,
+    );
+    bridge.execute(&pid);
+    assert_eq!(bridge.fee_token_rate(&token), 5000);
+}
+
+#[test]
+fn test_fee_token_rate_accepts_bounds() {
+    let (_env, bridge, token, admin) = full_setup(100);
+
+    let pid_min = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 1000),
+        &1000,
+    );
+    bridge.execute(&pid_min);
+    assert_eq!(bridge.fee_token_rate(&token), 1000);
+
+    let pid_max = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 20000),
+        &1000,
+    );
+    bridge.execute(&pid_max);
+    assert_eq!(bridge.fee_token_rate(&token), 20000);
+}
+
+#[test]
+#[should_panic(expected = "rate must be >= 1000")]
+fn test_fee_token_rate_rejects_below_min() {
+    let (_env, bridge, token, admin) = full_setup(100);
+    let pid = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 999),
+        &1000,
+    );
+    bridge.execute(&pid);
+}
+
+#[test]
+#[should_panic(expected = "rate must be <= 20000")]
+fn test_fee_token_rate_rejects_above_max() {
+    let (_env, bridge, token, admin) = full_setup(100);
+    let pid = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 20001),
+        &1000,
+    );
+    bridge.execute(&pid);
+}
+
+#[test]
+fn test_funding_with_whitelisted_fee_token_accrues_token_fees() {
+    let (env, bridge, token, admin) = full_setup(1000); // 10% fee
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+    TestTokenClient::new(&env, &token).mint(&source, &10000);
+
+    let pid_wl = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenWhitelist(token.clone(), true),
+        &1000,
+    );
+    bridge.execute(&pid_wl);
+
+    let pid_rate = bridge.propose(
+        &admin,
+        &ProposalAction::SetFeeTokenRate(token.clone(), 5000), // 50% of the fee
+        &1000,
+    );
+    bridge.execute(&pid_rate);
+
+    assert_eq!(bridge.accumulated_fees_for_token(&token), 0);
+
+    bridge.fund_c_address(
+        &source,
+        &target,
+        &token,
+        &1000,
+        &String::from_str(&env, "fee-token"),
+    );
+
+    // fee = 1000 * 1000bps / 10000 = 100; token_fee = 100 * 5000bps / 10000 = 50
+    assert_eq!(bridge.accumulated_fees(), 100);
+    assert_eq!(bridge.accumulated_fees_for_token(&token), 50);
+}
+
+#[test]
+fn test_funding_with_non_whitelisted_token_does_not_accrue_token_fees() {
+    let (env, bridge, token, _admin) = full_setup(1000);
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+    TestTokenClient::new(&env, &token).mint(&source, &10000);
+
+    bridge.fund_c_address(
+        &source,
+        &target,
+        &token,
+        &1000,
+        &String::from_str(&env, "no-whitelist"),
+    );
+
+    assert_eq!(bridge.accumulated_fees(), 100);
+    assert_eq!(bridge.accumulated_fees_for_token(&token), 0);
+}

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1495,6 +1495,48 @@ fn test_archive_no_entries_fails() {
 }
 
 #[test]
+fn test_archive_hash_differs_for_different_records() {
+    // Two independent envs perform the identical sequence of Address::generate
+    // calls, so source/target come out byte-identical across both. Only the
+    // funded amount differs, and only in a high byte: 1000 and 1256 share the
+    // same low byte (0xE8), which is exactly what the old hash implementation
+    // hashed (plus the low byte of `fee`, kept at 0 via fee_bps=0 here). Under
+    // the old truncating implementation these two batches would have hashed
+    // to the same value; the fix must tell them apart.
+    let (env1, bridge1, _admins1) = setup_env_with_admins(1, 1, 0, 1000);
+    let source1 = Address::generate(&env1);
+    let target1 = Address::generate(&env1);
+    let token1 = register_test_token(&env1);
+    TestTokenClient::new(&env1, &token1).mint(&source1, &10000);
+    bridge1.fund_c_address(
+        &source1,
+        &target1,
+        &token1,
+        &1000,
+        &String::from_str(&env1, "same-memo"),
+    );
+    let hash1 = bridge1.archive_old_entries(&1);
+
+    let (env2, bridge2, _admins2) = setup_env_with_admins(1, 1, 0, 1000);
+    let source2 = Address::generate(&env2);
+    let target2 = Address::generate(&env2);
+    let token2 = register_test_token(&env2);
+    TestTokenClient::new(&env2, &token2).mint(&source2, &10000);
+    bridge2.fund_c_address(
+        &source2,
+        &target2,
+        &token2,
+        &1256,
+        &String::from_str(&env2, "same-memo"),
+    );
+    let hash2 = bridge2.archive_old_entries(&1);
+
+    assert_eq!(source1, source2);
+    assert_eq!(target1, target2);
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
 fn test_batch_fund_then_funding_count() {
     let (env, bridge, _admins) = setup_env_with_admins(1, 1, 50, 1000);
     let source = Address::generate(&env);

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -864,6 +864,29 @@ fn test_set_fee_accepts_below_max() {
     assert_eq!(bridge.fee_bps(), 100);
 }
 
+#[test]
+fn test_initialization_params_stays_consistent_after_fee_change() {
+    let (_env, bridge, admins) = setup_env_with_admins(2, 2, 50, 1000);
+
+    // Right after init, both views must agree.
+    assert_eq!(bridge.fee_bps(), 50);
+    assert_eq!(bridge.initialization_params().fee_bps, 50);
+
+    let pid = bridge.propose(
+        &admins.get_unchecked(0),
+        &ProposalAction::SetFee(300),
+        &1000,
+    );
+    bridge.approve(&admins.get_unchecked(1), &pid);
+    bridge.execute(&pid);
+
+    // After a governance-approved fee change, initialization_params() must
+    // no longer report the stale deploy-time fee_bps.
+    assert_eq!(bridge.fee_bps(), 300);
+    assert_eq!(bridge.initialization_params().fee_bps, 300);
+    assert_eq!(bridge.initialization_params().fee_bps, bridge.fee_bps());
+}
+
 // ===========================================================================
 // Task 4: Multisig Governance Tests
 // ===========================================================================

--- a/contracts/onboarding-bridge/src/test.rs
+++ b/contracts/onboarding-bridge/src/test.rs
@@ -1438,7 +1438,7 @@ fn test_storage_usage() {
     assert_eq!(fund_count, 0);
     assert_eq!(archive_count, 0);
     assert_eq!(acc_fees, 0);
-    assert_eq!(hot, 5);
+    assert_eq!(hot, 0);
 
     bridge.fund_c_address(
         &source,
@@ -1448,9 +1448,16 @@ fn test_storage_usage() {
         &String::from_str(&env, "usage test"),
     );
 
-    let (fund_count, _, acc_fees, _) = bridge.storage_usage();
+    let (fund_count, _, acc_fees, hot) = bridge.storage_usage();
     assert_eq!(fund_count, 1);
     assert_eq!(acc_fees, 10);
+    assert_eq!(hot, 1);
+
+    bridge.archive_old_entries(&1);
+
+    let (_, archive_count, _, hot) = bridge.storage_usage();
+    assert_eq!(archive_count, 1);
+    assert_eq!(hot, 0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #241 
Closes #242 
Closes #243 
Closes #244 

Summary:

1. Archive hash truncation (weak integrity hash) — archive_old_entries now hashes the full byte representation of every relevant field per record (source, target, token_address, amount, fee, ledger, memo) instead of just the low byte of amount/fee. Added a regression test using amounts (1000 vs 1256) that share a low byte but differ in a higher byte — proving the old code would have collided and the new code doesn't.
2. Hardcoded storage_usage() stub — the 4th return value now counts funding records whose archived flag is still false (real "hot" storage), instead of a literal 5u32. Updated the test to exercise it across unfunded, funded-but-unarchived, and post-archive states.
3. Stale InitializationParams.fee_bps — the SetFee governance action now also updates DataKey::InitializationParams so initialization_params() never diverges from fee_bps() after a fee change. Added a test that changes the fee via a proposal and asserts both views agree.
4. Missing fee-token test coverage — added tests for whitelisting/unwhitelisting a fee token, rate defaults and updates, rate accepted at both bounds (1000/20000), rate rejected just outside both bounds, per-token fee accrual on funding through a whitelisted token, and no accrual for a non-whitelisted token.
