### PR TITLE
feat(middleware): implement maskValue, requestTracker, contentTypeEnforcement, registerWebhookVerifier

### DIFF
--- a/api/src/middleware/logging.ts
+++ b/api/src/middleware/logging.ts
@@ -8,7 +8,10 @@ const SENSITIVE_HEADER_NAMES = new Set([
 const sensitiveBodyFields = new Set(config.logging.sensitiveFields);
 
 export function maskValue(val: string): string {
-  throw new Error('Not implemented: maskValue');
+  // Values of 4 chars or fewer are masked whole: keeping a 4-char suffix of a
+  // 4-char secret would leak the entire value.
+  if (val.length <= 4) return '***';
+  return `***${val.slice(-4)}`;
 }
 
 export function maskHeaders(

--- a/api/src/middleware/requestTracker.ts
+++ b/api/src/middleware/requestTracker.ts
@@ -2,5 +2,28 @@ import { Request, Response, NextFunction } from 'express';
 import { gracefulShutdown } from '../shutdown';
 
 export function requestTracker(req: Request, res: Response, next: NextFunction): void {
-  throw new Error('Not implemented: requestTracker');
+  if (gracefulShutdown.shuttingDown) {
+    // Ask the client not to reuse this socket, so keep-alive connections don't
+    // keep landing on a server that is on its way out.
+    res.set('Connection', 'close');
+    res.status(503).json({ error: 'service_unavailable', message: 'server is shutting down' });
+    return;
+  }
+
+  gracefulShutdown.increment();
+
+  // 'finish' and 'close' can both fire for a single response (a normal finish
+  // is followed by close). The latch keeps the count honest — a double
+  // decrement here would let shutdown() drain early and cut off live requests.
+  let released = false;
+  const release = (): void => {
+    if (released) return;
+    released = true;
+    gracefulShutdown.decrement();
+  };
+
+  res.on('finish', release);
+  res.on('close', release);
+
+  next();
 }

--- a/api/src/middleware/security.ts
+++ b/api/src/middleware/security.ts
@@ -34,6 +34,10 @@ const SIZE_LIMITS: Record<string, number> = {
 
 const DEFAULT_LIMIT = 64 * 1024;
 
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH']);
+
+const ALLOWED_BODY_CONTENT_TYPES = new Set(['application/json']);
+
 function flattenValue(v: unknown): string[] {
   if (typeof v === 'string') return [v];
   if (Array.isArray(v)) return v.flatMap((item) => flattenValue(item));
@@ -61,7 +65,33 @@ function sanitizeErrorMessage(msg: string): string {
 }
 
 export function contentTypeEnforcement(req: Request, res: Response, next: NextFunction): void {
-  throw new Error('Not implemented: contentTypeEnforcement');
+  // Only methods that carry a body are worth gating. GET/HEAD/DELETE/OPTIONS
+  // are allowed through even when a client sends a stray Content-Type.
+  if (!BODY_METHODS.has(req.method.toUpperCase())) {
+    next();
+    return;
+  }
+
+  const header = req.headers['content-type'];
+  const raw = Array.isArray(header) ? header[0] : header;
+
+  // Strip parameters ('application/json; charset=utf-8') and compare only the
+  // media type, case-insensitively — RFC 9110 makes both case-insensitive.
+  const mediaType = (raw ?? '').split(';')[0].trim().toLowerCase();
+
+  if (!ALLOWED_BODY_CONTENT_TYPES.has(mediaType)) {
+    logger.warn(
+      { ip: req.ip, path: req.path, method: req.method, contentType: raw },
+      'rejected request with unsupported content-type',
+    );
+    res.status(415).json({
+      error: 'unsupported_media_type',
+      message: 'Content-Type must be application/json',
+    });
+    return;
+  }
+
+  next();
 }
 
 export function requestSizeLimiting(req: Request, res: Response, next: NextFunction): void {

--- a/api/src/middleware/webhookVerification.ts
+++ b/api/src/middleware/webhookVerification.ts
@@ -50,7 +50,12 @@ export const transakVerifier: WebhookVerifier = {
 const VERIFIERS: Record<string, { verifier: WebhookVerifier; secret: string }> = {};
 
 export function registerWebhookVerifier(provider: string, verifier: WebhookVerifier, secret: string): void {
-  throw new Error('Not implemented: registerWebhookVerifier');
+  // Re-registering a provider replaces its entry, which is what secret rotation
+  // needs: the new secret takes effect without a restart. buildWebhookVerifier
+  // reads VERIFIERS per request rather than closing over the entry, so the
+  // exported verifyMoonpayWebhook / verifyTransakWebhook handlers pick this up
+  // even though they were created at module load.
+  VERIFIERS[provider] = { verifier, secret };
 }
 
 const failedAttempts = new Map<string, { count: number; windowStart: number }>();


### PR DESCRIPTION
Closes #452
Closes #453
Closes #454
Closes #456

Four stubbed middleware bodies. Signatures and doc comments are untouched, as each issue asks — only the bodies changed. No other stub in these files was implemented, so the suite is still amber overall; the tests naming these four functions are what this PR targets.

## #452 — `maskValue` (`api/src/middleware/logging.ts`)

Keeps the last 4 characters and replaces the rest with a fixed `***`.

The fixed prefix matters: making the mask proportional to the input would leak the secret's length. Values of **4 characters or fewer are masked whole** — keeping a 4-char suffix of a 4-char value would return it verbatim, so `maskValue('1234')` is `'***'`, not `'1234'`.

## #453 — `requestTracker` (`api/src/middleware/requestTracker.ts`)

While `gracefulShutdown.shuttingDown` is set, responds `503 service_unavailable` and sets `Connection: close` so keep-alive clients stop reusing a socket to a server that is on its way out. Otherwise it increments the in-flight count and releases it when the response ends.

`release` is latched behind a `released` flag because **`finish` and `close` both fire for a normal response** — `close` follows `finish`. Without the latch each request would decrement twice, and a count that drifts below the true number of in-flight requests lets `shutdown()` resolve early and cut off requests that are still being served. (`GracefulShutdown.decrement` clamps at zero, so the symptom would be a premature drain rather than a negative count, which is the harder version to notice.)

Registering both events is still necessary: a client that disconnects mid-response fires `close` without `finish`, and that request must be released too or shutdown would hang until the timeout.

`/health` is mounted ahead of this middleware, so it keeps answering `503 shutting_down` during a drain rather than being intercepted here — that distinction is what `gracefulShutdown.test.ts` pins.

## #454 — `contentTypeEnforcement` (`api/src/middleware/security.ts`)

Requires `application/json` on `POST`/`PUT`/`PATCH`; anything else is `415 unsupported_media_type`. `GET`/`HEAD`/`DELETE`/`OPTIONS` pass through untouched, including when a client sends a stray `Content-Type`.

Only the media type is compared — parameters are split off, so `application/json; charset=utf-8` is accepted. The comparison is lowercased and the method is upper-cased first, since RFC 9110 makes both case-insensitive. A repeated header arrives as an array, so the first value is used rather than stringifying the array into something that matches nothing.

Method and allowed-type sets are module-level constants alongside the existing `SIZE_LIMITS` table, so widening the allowlist later is a one-line change.

## #456 — `registerWebhookVerifier` (`api/src/middleware/webhookVerification.ts`)

Writes the `{ verifier, secret }` entry into the `VERIFIERS` registry.

Re-registering a provider **replaces** the entry rather than being ignored, which is what secret rotation needs and what `webhookVerification.test.ts` relies on — it re-registers both providers in `beforeEach`, so an insert-once implementation would pass the first test and then quietly serve a stale secret to the rest.

This works on the already-exported `verifyMoonpayWebhook` / `verifyTransakWebhook` because `buildWebhookVerifier` looks the provider up in `VERIFIERS` per request instead of closing over the entry at module load. Nothing needs re-wiring after a rotation.

## Testing

`npm install` fails in this environment (the workspace install can't reach the registry here), so I did not run the suite — the implementations are written against the assertions in `api/src/__tests__/logging.test.ts`, `security.test.ts`, `gracefulShutdown.test.ts`, and `webhookVerification.test.ts`. Worth a CI run before merge.

Note for #453: `gracefulShutdown.test.ts` exercises the middleware by **inlining a copy** of the logic against a private `GracefulShutdown` instance rather than importing `requestTracker`. The implementation matches that copy, but those tests would pass even if `requestTracker` were still throwing — so they aren't real evidence for this function. The `/health` shutdown test does exercise the real app path.
