### PR TITLE
feat(api): implement secrets loading, API versioning, and abuse alerts

### DIFF
--- a/api/src/__tests__/abuseAlert.test.ts
+++ b/api/src/__tests__/abuseAlert.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { logger } from '../logger';
+
+const ALERT_URL = 'https://admin.example.com/alerts';
+
+async function loadModule() {
+  return import('../services/abuseAlert');
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.ADMIN_ALERT_URL;
+  vi.unstubAllGlobals();
+});
+
+describe('sendAbuseAlert', () => {
+  it('logs every alert at error level', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { sendAbuseAlert } = await loadModule();
+    await sendAbuseAlert({ type: 'ip_banned', ip: '10.0.0.1', pattern: 'large_amount' });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        alert: true,
+        abuse: expect.objectContaining({ type: 'ip_banned', ip: '10.0.0.1' }),
+      }),
+      'abuse detected: ip_banned',
+    );
+  });
+
+  it('does not call the webhook when ADMIN_ALERT_URL is unset', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { sendAbuseAlert } = await loadModule();
+    await sendAbuseAlert({ type: 'suspicious_activity', ip: '10.0.0.2' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('posts the enriched payload to ADMIN_ALERT_URL when configured', async () => {
+    process.env.ADMIN_ALERT_URL = ALERT_URL;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { sendAbuseAlert } = await loadModule();
+    await sendAbuseAlert({ type: 'cost_limit_exceeded', ip: '10.0.0.3', apiKeyId: 'key-1', details: { totalCost: 1_000_001 } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(ALERT_URL);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ 'content-type': 'application/json' });
+
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      type: 'cost_limit_exceeded',
+      ip: '10.0.0.3',
+      apiKeyId: 'key-1',
+      details: { totalCost: 1_000_001 },
+      service: 'bridge-api',
+    });
+    expect(Date.parse(body.timestamp)).not.toBeNaN();
+  });
+
+  it('swallows delivery failures so abuse detection never throws', async () => {
+    process.env.ADMIN_ALERT_URL = ALERT_URL;
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { sendAbuseAlert } = await loadModule();
+    await expect(sendAbuseAlert({ type: 'ip_banned', ip: '10.0.0.4' })).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      'failed to deliver admin abuse alert',
+    );
+  });
+});

--- a/api/src/__tests__/loggerRedact.test.ts
+++ b/api/src/__tests__/loggerRedact.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.NODE_ENV = 'test';
+process.env.SOROBAN_RPC_URL = 'https://soroban-rpc.testnet.stellar.org';
+process.env.BRIDGE_FEE_BPS = '30';
+process.env.API_KEYS = 'test-api-key-123';
+
+vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+  ok: true,
+  json: vi.fn().mockResolvedValue({}),
+  text: vi.fn().mockResolvedValue('ok'),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.LOG_SENSITIVE_FIELDS;
+});
+
+describe('logger redaction paths', () => {
+  it('accepts configured field names that are not bare identifiers', async () => {
+    // `x-api-key` is part of the default LOG_SENSITIVE_FIELDS list; pino rejects
+    // it as a redact path unless it is quoted with bracket notation.
+    process.env.LOG_SENSITIVE_FIELDS = 'apiKey,x-api-key,x-forwarded-for';
+
+    await expect(import('../logger')).resolves.toBeDefined();
+  });
+
+  it('builds a logger with the default sensitive field list', async () => {
+    const { logger } = await import('../logger');
+
+    expect(typeof logger.info).toBe('function');
+  });
+});

--- a/api/src/__tests__/versioning.test.ts
+++ b/api/src/__tests__/versioning.test.ts
@@ -1,0 +1,111 @@
+import { Request, Response, NextFunction } from 'express';
+import { describe, it, expect, vi } from 'vitest';
+import { versionCompatibility } from '../middleware/versioning';
+
+function buildReq(overrides: { path?: string; headers?: Record<string, string>; query?: Record<string, string> } = {}): Request {
+  const headers = overrides.headers ?? {};
+  return {
+    path: overrides.path ?? '/api/quote',
+    query: overrides.query ?? {},
+    get: (name: string) => headers[name.toLowerCase()],
+  } as unknown as Request;
+}
+
+function buildRes(): { res: Response; headers: Record<string, string> } {
+  const headers: Record<string, string> = {};
+  const res = {
+    set: vi.fn((name: string, value: string) => {
+      headers[name.toLowerCase()] = value;
+      return res;
+    }),
+  } as unknown as Response;
+  return { res, headers };
+}
+
+describe('versionCompatibility', () => {
+  it('resolves the version from the request path', () => {
+    const req = buildReq({ path: '/api/v2/quote' });
+    const { res, headers } = buildRes();
+    const next = vi.fn() as NextFunction;
+
+    versionCompatibility(req, res, next);
+
+    expect(headers['x-api-version']).toBe('v2');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('resolves the version from the Accept header', () => {
+    const req = buildReq({ headers: { accept: 'application/vnd.bridge+json; version=2' } });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers['x-api-version']).toBe('v2');
+  });
+
+  it('resolves the version from the X-API-Version header', () => {
+    const req = buildReq({ headers: { 'x-api-version': 'v2' } });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers['x-api-version']).toBe('v2');
+  });
+
+  it('resolves the version from the query string', () => {
+    const req = buildReq({ query: { version: '2' } });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers['x-api-version']).toBe('v2');
+  });
+
+  it('prefers the path version over the Accept header', () => {
+    const req = buildReq({ path: '/api/v1/quote', headers: { accept: 'application/vnd.bridge+json; version=2' } });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers['x-api-version']).toBe('v1');
+  });
+
+  it('defaults to v1 when no version is supplied', () => {
+    const req = buildReq();
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers['x-api-version']).toBe('v1');
+  });
+
+  it('exposes deprecation headers for v1 requests', () => {
+    const req = buildReq({ path: '/api/v1/quote' });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers.deprecation).toBe('true');
+    expect(headers.sunset).toBe('2027-12-31');
+    expect(headers.link).toContain('rel="successor-version"');
+  });
+
+  it('does not deprecate v2 requests', () => {
+    const req = buildReq({ path: '/api/v2/quote' });
+    const { res, headers } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect(headers.deprecation).toBeUndefined();
+    expect(headers.sunset).toBeUndefined();
+  });
+
+  it('attaches the resolved version to the request', () => {
+    const req = buildReq({ path: '/api/v2/quote' });
+    const { res } = buildRes();
+
+    versionCompatibility(req, res, vi.fn() as NextFunction);
+
+    expect((req as Request & { apiVersion?: string }).apiVersion).toBe('v2');
+  });
+});

--- a/api/src/logger.ts
+++ b/api/src/logger.ts
@@ -144,21 +144,30 @@ if (process.env.LOGTAIL_TOKEN) {
   aggregationHeaders.authorization = `Bearer ${process.env.LOGTAIL_TOKEN}`;
 }
 
+// pino only accepts bare identifiers as redact path segments, so configured
+// field names such as `x-api-key` have to be quoted with bracket notation.
+function toRedactPath(field: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(field) ? field : `["${field}"]`;
+}
+
 const sensitivePaths = [
-  'req.headers.authorization',
-  'req.headers["x-api-key"]',
-  'authorization',
-  'password',
-  'token',
-  'apiKey',
-  'signedXdr',
-  'privateKey',
-  'mnemonic',
-  'secret',
-  'secretKey',
-  ...config.logging.sensitiveFields
-    .map((f) => f.trim())
-    .filter(Boolean),
+  ...new Set([
+    'req.headers.authorization',
+    'req.headers["x-api-key"]',
+    'authorization',
+    'password',
+    'token',
+    'apiKey',
+    'signedXdr',
+    'privateKey',
+    'mnemonic',
+    'secret',
+    'secretKey',
+    ...config.logging.sensitiveFields
+      .map((f) => f.trim())
+      .filter(Boolean)
+      .map(toRedactPath),
+  ]),
 ];
 
 const stream = new AggregationStream(

--- a/api/src/middleware/cache.ts
+++ b/api/src/middleware/cache.ts
@@ -46,21 +46,3 @@ function defaultKeyFn(req: Request): string {
 export function cacheMiddleware(opts: CacheMiddlewareOptions): RequestHandler {
   throw new Error('Not implemented: cacheMiddleware');
 }
-
-    // Cache miss – let the handler run, then intercept res.json to cache the body.
-    res.setHeader('X-Cache', 'MISS');
-
-    const originalJson = res.json.bind(res);
-    res.json = (body: unknown): Response => {
-      // Only cache successful responses.
-      if (res.statusCode >= 200 && res.statusCode < 300) {
-        swrSet(discriminator, body, opts.ttl).catch(() => {
-          // Don't break the response if caching fails.
-        });
-      }
-      return originalJson(body);
-    };
-
-    next();
-  };
-}

--- a/api/src/middleware/rbacAuth.ts
+++ b/api/src/middleware/rbacAuth.ts
@@ -106,27 +106,8 @@ function isIpAllowed(ip: string, whitelist: string[]): boolean {
   return whitelist.some((cidr) => matchesCidr(ip, cidr));
 }
 
-export function createApiKey(input: CreateKeyInput): {
+export function createApiKey(input: CreateKeyInput): { rawKey: string; record: ApiKeyRecord } {
   throw new Error('Not implemented: createApiKey');
-} {
-  const rawKey = `cab_${crypto.randomBytes(32).toString('hex')}`;
-  const now = Date.now();
-  const record: ApiKeyRecord = {
-    id: crypto.randomUUID(),
-    keyHash: hashKey(rawKey),
-    name: input.name,
-    createdBy: input.createdBy,
-    createdAt: now,
-    updatedAt: now,
-    lastUsedAt: null,
-    scopes: input.scopes,
-    ipWhitelist: input.ipWhitelist ?? [],
-    expiresAt: input.expiresAt ?? null,
-    rateLimit: input.rateLimit ?? 'standard',
-    revoked: false,
-  };
-  keyStore.set(record.id, record);
-  return { rawKey, record };
 }
 
 export function revokeApiKey(id: string): boolean {

--- a/api/src/middleware/versioning.ts
+++ b/api/src/middleware/versioning.ts
@@ -40,5 +40,16 @@ function resolveVersion(req: Request): ApiVersion {
 }
 
 export function versionCompatibility(req: Request, res: Response, next: NextFunction) {
-  throw new Error('Not implemented: versionCompatibility');
+  const version = resolveVersion(req);
+  const reqWithVersion = req as Request & { apiVersion?: ApiVersion };
+  reqWithVersion.apiVersion = version;
+
+  res.set('X-API-Version', version);
+  if (version === 'v1') {
+    res.set('Deprecation', 'true');
+    res.set('Sunset', '2027-12-31');
+    res.set('Link', '<https://docs.example.com/api/versioning>; rel="successor-version"');
+  }
+
+  next();
 }

--- a/api/src/secrets/manager.ts
+++ b/api/src/secrets/manager.ts
@@ -83,7 +83,43 @@ function readSecret(provider: SecretsProviderName, definition: SecretDefinition,
 }
 
 export function initializeSecrets(): void {
-  throw new Error('Not implemented: initializeSecrets');
+  if (initialized) return;
+  initialized = true;
+
+  const provider = providerName();
+  if (provider === 'env') return;
+
+  const service = process.env.SECRETS_SERVICE_NAME || process.env.SERVICE_NAME || 'api';
+  const definitions = definitionsForService(service);
+  const localSecrets = provider === 'local-encrypted' ? decryptLocalFile() : {};
+
+  for (const definition of definitions) {
+    const baseEvent = {
+      ts: new Date().toISOString(),
+      provider,
+      service,
+      env: definition.env,
+      path: `${prefix()}/${definition.path}`,
+    };
+
+    if (process.env[definition.env]) {
+      audit({ ...baseEvent, result: 'skipped-existing' });
+      continue;
+    }
+
+    try {
+      const value = readSecret(provider, definition, localSecrets);
+      if (!value) {
+        audit({ ...baseEvent, result: 'missing' });
+        continue;
+      }
+      process.env[definition.env] = value;
+      audit({ ...baseEvent, result: 'loaded' });
+    } catch (err) {
+      audit({ ...baseEvent, result: 'error', message: err instanceof Error ? err.message : String(err) });
+      if (definition.critical || process.env.SECRETS_STRICT === 'true') throw err;
+    }
+  }
 }
 
 export function localSecretFilePath(): string {

--- a/api/src/secrets/schema.ts
+++ b/api/src/secrets/schema.ts
@@ -80,5 +80,5 @@ export const secretSchema: SecretDefinition[] = [
 ];
 
 export function definitionsForService(service: string): SecretDefinition[] {
-  throw new Error('Not implemented: definitionsForService');
+  return secretSchema.filter((definition) => definition.service === 'shared' || definition.service === service);
 }

--- a/api/src/services/abuseAlert.ts
+++ b/api/src/services/abuseAlert.ts
@@ -11,5 +11,24 @@ export interface AbuseAlertPayload {
 }
 
 export async function sendAbuseAlert(payload: AbuseAlertPayload): Promise<void> {
-  throw new Error('Not implemented: sendAbuseAlert');
+  logger.error(
+    { alert: true, abuse: payload },
+    `abuse detected: ${payload.type}`,
+  );
+
+  if (!ADMIN_ALERT_URL) return;
+
+  try {
+    await fetch(ADMIN_ALERT_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        ...payload,
+        service: 'bridge-api',
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch (err) {
+    logger.warn({ err, payload }, 'failed to deliver admin abuse alert');
+  }
 }

--- a/api/src/services/cache.ts
+++ b/api/src/services/cache.ts
@@ -172,9 +172,7 @@ export interface SWREntry<T = unknown> {
  * Returns `{ value, stale }` where `stale=true` means the entry is past its
  * primary TTL but still within the SWR extension window.
  */
-export async function swrGet<T>(key: string): Promise<{
-  throw new Error('Not implemented: swrGet');
-} | null> {
+export async function swrGet<T>(key: string): Promise<{ value: T; stale: boolean } | null> {
   const redis = getClient();
   if (!redis) return null;
 
@@ -253,7 +251,44 @@ export async function withSingleFlight<T>(
   lockTtlMs = 5000,
 ): Promise<T> {
   throw new Error('Not implemented: withSingleFlight');
-});
+}
+
+// ─── Combined get-or-compute (the main high-level helper) ─────────────────────
+
+/**
+ * Attempt to read `key` from the cache using stale-while-revalidate semantics.
+ *
+ * - Cache HIT (fresh)  → return cached value immediately.
+ * - Cache HIT (stale)  → return stale value immediately AND trigger background revalidation.
+ * - Cache MISS         → use `withSingleFlight` to compute the value, cache it, and return it.
+ *
+ * @param key         Cache key.
+ * @param ttlSeconds  Primary TTL for fresh data.
+ * @param compute     Async factory invoked on cache miss (or background revalidation).
+ */
+export async function getOrCompute<T>(
+  key: string,
+  ttlSeconds: number,
+  compute: () => Promise<T>,
+): Promise<T> {
+  const cached = await swrGet<T>(key);
+
+  if (cached !== null) {
+    if (!cached.stale) {
+      // Fresh hit – return immediately.
+      return cached.value;
+    }
+
+    // Stale hit – return immediately but kick off background revalidation.
+    // Fire-and-forget; errors are silently swallowed to avoid impacting the response.
+    setImmediate(() => {
+      withSingleFlight(key, async () => {
+        const fresh = await compute();
+        await swrSet(key, fresh, ttlSeconds);
+        return JSON.stringify(fresh);
+      }).catch(() => {
+        // Background revalidation errors don't affect the caller.
+      });
     });
 
     return cached.value;
@@ -270,14 +305,19 @@ export async function withSingleFlight<T>(
 // ─── Metrics accessors ────────────────────────────────────────────────────────
 
 export function getCacheMetrics(): CacheMetrics {
-  throw new Error('Not implemented: getCacheMetrics');
+  const total = _hits + _misses;
+  return {
+    hits: _hits,
+    misses: _misses,
+    hitRatio: total > 0 ? _hits / total : 0,
+  };
 }
 
 export function isRedisEnabled(): boolean {
-  throw new Error('Not implemented: isRedisEnabled');
+  return config.redis.enabled;
 }
 
 /** Expose the internal Redis client for callers that need direct access (e.g. tests). */
 export function getCacheClient(): Redis | null {
-  throw new Error('Not implemented: getCacheClient');
+  return getClient();
 }

--- a/api/src/services/db.ts
+++ b/api/src/services/db.ts
@@ -4,7 +4,7 @@ import { config } from '../config';
 import { logger } from '../logger';
 import { register } from './metrics';
 
-let pool: Pool | null = null;
+const pool: Pool | null = null;
 
 export function getPool(): Pool | null {
   throw new Error('Not implemented: getPool');
@@ -62,9 +62,7 @@ new Gauge({
   },
 });
 
-export async function dbHealthCheck(): Promise<{
-  throw new Error('Not implemented: dbHealthCheck');
-}> {
+export async function dbHealthCheck(): Promise<{ ok: boolean; latencyMs?: number; error?: string }> {
   const p = getPool();
   if (!p) return { ok: true };
 

--- a/api/src/services/transactions.ts
+++ b/api/src/services/transactions.ts
@@ -106,36 +106,8 @@ function parseAmount(value: string): number {
   return Number.parseFloat(value);
 }
 
-export function listTransactions(params: TransactionQueryParams = {}): {
+export function listTransactions(params: TransactionQueryParams = {}): { data: TransactionRecord[]; nextCursor: string | null; hasMore: boolean } {
   throw new Error('Not implemented: listTransactions');
-} {
-  const limit = Math.min(Math.max(params.limit ?? 20, 1), 100);
-  const fromDate = params.fromDate ? Date.parse(params.fromDate) : undefined;
-  const toDate = params.toDate ? Date.parse(params.toDate) : undefined;
-  const minAmount = params.minAmount ? parseAmount(params.minAmount) : undefined;
-  const maxAmount = params.maxAmount ? parseAmount(params.maxAmount) : undefined;
-
-  const filtered = transactionStore
-    .filter((tx) => (params.status ? tx.status === params.status : true))
-    .filter((tx) => (fromDate !== undefined ? new Date(tx.createdAt).getTime() >= fromDate : true))
-    .filter((tx) => (toDate !== undefined ? new Date(tx.createdAt).getTime() <= toDate : true))
-    .filter((tx) => (minAmount !== undefined ? parseAmount(tx.amount) >= minAmount : true))
-    .filter((tx) => (maxAmount !== undefined ? parseAmount(tx.amount) <= maxAmount : true))
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-
-  let page = filtered;
-  if (params.cursor) {
-    const cursorTime = Date.parse(params.cursor);
-    page = page.filter((tx) => new Date(tx.createdAt).getTime() < cursorTime);
-  } else if (params.offset) {
-    page = page.slice(params.offset);
-  }
-
-  const hasMore = page.length > limit;
-  const slice = page.slice(0, limit);
-  const nextCursor = hasMore ? slice[slice.length - 1]?.createdAt ?? null : null;
-
-  return { data: slice, nextCursor, hasMore };
 }
 
 export function serializeTransactionsCsv(transactions: TransactionRecord[]): string {
@@ -150,9 +122,7 @@ export function getFeeConfig(): FeeConfigState {
   throw new Error('Not implemented: getFeeConfig');
 }
 
-export function updateFeeConfig(feeBps: number, timelockMs: number): {
-  throw new Error('Not implemented: updateFeeConfig');
-} {
+export function updateFeeConfig(feeBps: number, timelockMs: number): { pendingFeeBps: number; timelockUntil: number } {
   const timelockUntil = Date.now() + timelockMs;
   feeConfigState = {
     ...feeConfigState,
@@ -164,9 +134,7 @@ export function updateFeeConfig(feeBps: number, timelockMs: number): {
   return { pendingFeeBps: feeBps, timelockUntil };
 }
 
-export function withdrawAccumulatedFees(): {
-  throw new Error('Not implemented: withdrawAccumulatedFees');
-} {
+export function withdrawAccumulatedFees(): { withdrawn: string; status: 'completed' } {
   const withdrawn = accumulatedFees;
   accumulatedFees = '0.00';
   logger.info({ withdrawn }, 'accumulated fees withdrawn');

--- a/cex/withdrawal-router.ts
+++ b/cex/withdrawal-router.ts
@@ -101,14 +101,8 @@ export function createCexWithdrawalMemo(targetCAddress: string, exchangeName: st
  *
  * @param memo - Memo string from a Stellar transaction.
  */
-export function parseCexWithdrawalMemo(memo: string): {
+export function parseCexWithdrawalMemo(memo: string): { exchangeName?: string; targetSuffix?: string } {
   throw new Error('Not implemented: parseCexWithdrawalMemo');
-} {
-  const parts = memo.split(':');
-  if (parts.length === 3 && parts[0] === 'bridge') {
-    return { exchangeName: parts[1], targetSuffix: parts[2] };
-  }
-  return {};
 }
 
 /** POSTs to an exchange endpoint, aborting after 15s so a hung exchange API can't hang the caller. */

--- a/sdk/src/token.ts
+++ b/sdk/src/token.ts
@@ -4,17 +4,13 @@ import { ValidationError } from './errors';
 // ─── Token Type Guards ────────────────────────────────────────────────────────
 
 /** Returns `true` if the token is the native XLM asset. */
-export function isNativeToken(token: Token): token is {
+export function isNativeToken(token: Token): token is { type: 'native' } {
   throw new Error('Not implemented: isNativeToken');
-} {
-  return token.type === 'native';
 }
 
 /** Returns `true` if the token is a SAC (Stellar Asset Converter) token. */
-export function isSacToken(token: Token): token is {
+export function isSacToken(token: Token): token is { type: 'sac'; contractId: string } {
   throw new Error('Not implemented: isSacToken');
-} {
-  return token.type === 'sac';
 }
 
 // ─── Address Validation ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements four stubbed functions from the seeded-exercise state, one commit per issue, plus two baseline fixes that were keeping the repo from building at all.

| Function | File | Issue |
|---|---|---|
| `definitionsForService()` | `api/src/secrets/schema.ts` | Closes #458 |
| `initializeSecrets()` | `api/src/secrets/manager.ts` | Closes #457 |
| `versionCompatibility()` | `api/src/middleware/versioning.ts` | Closes #455 |
| `sendAbuseAlert()` | `api/src/services/abuseAlert.ts` | Closes #459 |

Signatures, generics, return types, and doc comments are unchanged — only the bodies.

### What each one does

- **`definitionsForService`** — returns the definitions scoped to the given service plus everything marked `shared`, so a worker never loads API-only secrets.
- **`initializeSecrets`** — loads service-scoped secrets from the configured provider into `process.env` exactly once, never overwriting values that are already set. Each definition is audited as `loaded` / `missing` / `error` / `skipped-existing`. Errors only propagate for `critical` secrets or when `SECRETS_STRICT=true`, so one unavailable secret cannot stop the API from booting.
- **`versionCompatibility`** — resolves the requested version (path → `Accept` → `X-API-Version` → query, defaulting to `v1`), attaches it to the request, sets `X-API-Version`, and advertises the v1 sunset via `Deprecation`, `Sunset`, and `Link` headers.
- **`sendAbuseAlert`** — logs every abuse signal at error level and forwards it to `ADMIN_ALERT_URL` when configured. Delivery failures are logged and swallowed so alerting can never break the request path that detected the abuse.

## Baseline fixes (separate commits)

**`fix(api): quote non-identifier pino redact paths`** — the default `LOG_SENSITIVE_FIELDS` list contains `x-api-key`, which pino rejects as a redact path because it is not a bare identifier, so building the logger threw at import time and took down every module importing it. This was masked on `main` because `config.ts` calls `initializeSecrets()` at import and that threw first. Configured field names are now bracket-quoted when needed and the path list is de-duplicated. Covered by a regression test that fails without the fix.

**`fix(api): repair return types mangled by the exercise seeding`** — the seeding commit (`d2a6c17`) replaced the first braced block after each signature. For functions with an *inline object return type* that block was the type annotation, not the body:

```ts
export async function dbHealthCheck(): Promise<{
  throw new Error('Not implemented: dbHealthCheck');
}> {
```

Nine functions across `api`, `cex`, and `sdk` came out unparseable, so `tsc` aborted before type checking and vitest could not import the modules at all. Two more (`cacheMiddleware`, `withSingleFlight`) had a stub inserted mid-body, orphaning the remainder of the original function.

The commit restores the annotations and drops the orphaned fragments, **leaving the exercise intact**:

- Body stays stubbed where an implementation issue is still open — `createApiKey` (#504), `listTransactions` (#467), `parseCexWithdrawalMemo` (#500), `cacheMiddleware` (#448), `isNativeToken` (#475), `isSacToken` (#498), `withSingleFlight`.
- Original body kept where the seeding damaged a function without filing an issue — `swrGet`, `dbHealthCheck`, `updateFeeConfig`, `withdrawAccumulatedFees`, `getOrCompute`.

No behaviour change.

## Tests

New unit tests: `versioning.test.ts` (9), `abuseAlert.test.ts` (4), `loggerRedact.test.ts` (2, a regression test for the pino fix). The existing `secrets.test.ts` now passes and covers `definitionsForService` and `initializeSecrets`.

```
npx vitest run --root api src/__tests__/secrets.test.ts src/__tests__/versioning.test.ts \
  src/__tests__/abuseAlert.test.ts src/__tests__/loggerRedact.test.ts
# Test Files  4 passed (4)
#      Tests  17 passed (17)
```

| | `main` | this branch |
|---|---|---|
| Tests collected | 363 | 493 |
| Passing | 118 | 175 |

Test-by-test diff over the repair commit: **20 newly passing, 0 regressions.**

The rise in collected tests is the point of the repair — ~130 tests could not even be imported before. Those newly-running tests fail against the functions that are still stubbed for their own open issues.

## CI

CI is still red, and was before this PR. Two independent pre-existing reasons:

1. **`api` type check** — 24 type errors already failed at the pre-seeding commit `27b0235` (verified by type checking that commit directly), all in test files. The rest are `Argument of type 'void' is not assignable to RequestHandlerParams` in `routes/*.ts`, i.e. the still-open stubs returning `never`. Those clear as the remaining issues land.
2. **`sdk` / `hooks`** — `sdk/src/errors.ts` imports `./i18n`, which does not exist in the repo and never did (not present at `27b0235` either), plus a duplicate `TimeoutError` and a missing `generateIdempotencyKey`. `hooks` fails only because it builds `sdk` first.

Neither is caused by this branch, and both are outside the four issues it closes. Worth a maintainer issue of its own — happy to open one.
