### PR TITLE
Implement missing job processor functions

### DIFF
--- a/api/src/jobs/processors/asyncAuditLog.ts
+++ b/api/src/jobs/processors/asyncAuditLog.ts
@@ -7,5 +7,21 @@ import pino from 'pino';
 const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
 
 export async function processAuditLog(job: Job<AuditLogJobData>): Promise<void> {
-  throw new Error('Not implemented: processAuditLog');
+  const end = asyncPipelineJobDuration.startTimer();
+  try {
+    const { type, payload, actor, triggeredAt } = job.data;
+    integrityAuditLog.append({
+      type: type as AuditEventType,
+      payload,
+      actor,
+      triggeredAt,
+    });
+    logger.debug({ jobId: job.id, type }, 'audit log processed');
+  } catch (error) {
+    asyncPipelineFailureCounter.inc();
+    logger.error({ jobId: job.id, error }, 'failed to process audit log');
+    throw error;
+  } finally {
+    end();
+  }
 }

--- a/api/src/jobs/processors/asyncPipeline.ts
+++ b/api/src/jobs/processors/asyncPipeline.ts
@@ -9,7 +9,20 @@ const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
 type PipelineJobData = AnalyticsJobData | PipelineMetricsJobData;
 
 export async function processAsyncPipeline(job: Job<PipelineJobData>): Promise<void> {
-  throw new Error('Not implemented: processAsyncPipeline');
+  const end = asyncPipelineJobDuration.startTimer();
+  try {
+    if ('batch' in job.data) {
+      await processAnalytics(job as Job<AnalyticsJobData>);
+    } else {
+      await processPipelineMetrics(job as Job<PipelineMetricsJobData>);
+    }
+  } catch (error) {
+    asyncPipelineFailureCounter.inc();
+    logger.error({ jobId: job.id, error }, 'failed to process async pipeline job');
+    throw error;
+  } finally {
+    end();
+  }
 }
 
 async function processAnalytics(job: Job<AnalyticsJobData>): Promise<void> {

--- a/api/src/jobs/processors/cacheWarmup.ts
+++ b/api/src/jobs/processors/cacheWarmup.ts
@@ -17,5 +17,23 @@ const WARMUP_AMOUNT = '10000000';
 const WARMUP_ADDRESS = 'GABCDE2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 
 export async function processCacheWarmup(job: Job<CacheWarmupData>): Promise<void> {
-  throw new Error('Not implemented: processCacheWarmup');
+  const { assets } = job.data;
+  logger.debug({ jobId: job.id, assetCount: assets.length }, 'warming up cache');
+
+  const results = await Promise.allSettled(
+    assets.map(async (asset) => {
+      const quote = await sorobanService.getQuote(asset, WARMUP_AMOUNT, WARMUP_ADDRESS);
+      const cacheKey = buildCacheKey('quote', `${asset}:${WARMUP_AMOUNT}:${WARMUP_ADDRESS}`);
+      await swrSet(cacheKey, quote, CACHE_TTL.quote);
+      logger.debug({ jobId: job.id, asset }, 'cache warmed');
+    }),
+  );
+
+  const failures = results.filter((r) => r.status === 'rejected');
+  if (failures.length > 0) {
+    logger.warn(
+      { jobId: job.id, failureCount: failures.length, totalAssets: assets.length },
+      'some assets failed to warm',
+    );
+  }
 }

--- a/api/src/jobs/worker.ts
+++ b/api/src/jobs/worker.ts
@@ -30,7 +30,8 @@ export function startWorkers(): Worker[] {
 }
 
 export async function stopWorkers(workers: Worker[]): Promise<void> {
-  throw new Error('Not implemented: stopWorkers');
+  await Promise.all(workers.map((worker) => worker.close()));
+  await closeQueues();
 }
 
 // Standalone worker entry point


### PR DESCRIPTION
Implement the four missing job processor functions across the codebase.

## Changes
- Implemented stopWorkers() to gracefully close all job workers
- Implemented processAuditLog() to append audit events asynchronously  
- Implemented processAsyncPipeline() to dispatch analytics and metrics jobs
- Implemented processCacheWarmup() to pre-warm quote cache

## Closes
- Closes #440
- Closes #441
- Closes #442
- Closes #443