### PR TITLE
feat: implement queue and worker functions

### DIFF
--- a/api/src/jobs/queue.ts
+++ b/api/src/jobs/queue.ts
@@ -172,7 +172,8 @@ export async function enqueuePipelineMetrics(data: PipelineMetricsJobData): Prom
 }
 
 export async function enqueueWebhookRetry(data: WebhookRetryData): Promise<void> {
-  throw new Error('Not implemented: enqueueWebhookRetry');
+  const queues = getQueues();
+  await queues.webhookRetry.add('webhook-retry', data);
 }
 
 /** Returns the number of waiting (not yet picked up) jobs in a queue. */

--- a/api/src/jobs/queue.ts
+++ b/api/src/jobs/queue.ts
@@ -178,5 +178,7 @@ export async function enqueueWebhookRetry(data: WebhookRetryData): Promise<void>
 
 /** Returns the number of waiting (not yet picked up) jobs in a queue. */
 export async function getQueueWaitingCount(queueName: 'async-critical' | 'async-pipeline'): Promise<number> {
-  throw new Error('Not implemented: getQueueWaitingCount');
+  const queues = getQueues();
+  const queue = queueName === 'async-critical' ? queues.asyncCritical : queues.asyncPipeline;
+  return queue.count();
 }

--- a/api/src/jobs/queue.ts
+++ b/api/src/jobs/queue.ts
@@ -145,11 +145,13 @@ function getQueues() {
 }
 
 export function getAllQueues(): Queue[] {
-  throw new Error('Not implemented: getAllQueues');
+  return getQueues().all;
 }
 
 export async function closeQueues(): Promise<void> {
-  throw new Error('Not implemented: closeQueues');
+  const queues = getQueues();
+  await Promise.all(queues.all.map(q => q.close()));
+  _queues = null;
 }
 
 export async function scheduleRecurringJobs(): Promise<void> {
@@ -165,7 +167,8 @@ export async function enqueueAnalytics(data: AnalyticsJobData): Promise<void> {
 }
 
 export async function enqueuePipelineMetrics(data: PipelineMetricsJobData): Promise<void> {
-  throw new Error('Not implemented: enqueuePipelineMetrics');
+  const queues = getQueues();
+  await queues.asyncPipeline.add('pipeline-metrics', data);
 }
 
 export async function enqueueWebhookRetry(data: WebhookRetryData): Promise<void> {

--- a/api/src/jobs/worker.ts
+++ b/api/src/jobs/worker.ts
@@ -1,7 +1,7 @@
 import { Worker, WorkerOptions } from 'bullmq';
 import pino from 'pino';
 import { config } from '../config';
-import { getAllQueues, closeQueues } from './queue';
+import { closeQueues } from './queue';
 import { processCacheWarmup } from './processors/cacheWarmup';
 import { processMetrics } from './processors/metrics';
 import { processCleanup } from './processors/cleanup';
@@ -26,11 +26,32 @@ function makeWorkerOptions(concurrency: number): WorkerOptions {
 }
 
 export function startWorkers(): Worker[] {
-  throw new Error('Not implemented: startWorkers');
+  const workers: Worker[] = [];
+
+  workers.push(
+    new Worker('cache-warmup', processCacheWarmup, makeWorkerOptions(2)),
+    new Worker('metrics-compute', processMetrics, makeWorkerOptions(1)),
+    new Worker('cleanup', processCleanup, makeWorkerOptions(1)),
+    new Worker('async-critical', processAuditLog, makeWorkerOptions(5)),
+    new Worker('async-pipeline', processAsyncPipeline, makeWorkerOptions(10)),
+    new Worker('webhook-retry', processWebhookRetry, makeWorkerOptions(3)),
+  );
+
+  workers.forEach(worker => {
+    worker.on('completed', (job) => {
+      logger.debug({ jobId: job.id, queueName: job.queueName }, 'Job completed');
+    });
+    worker.on('failed', (job, err) => {
+      logger.error({ jobId: job?.id, queueName: job?.queueName, error: err.message }, 'Job failed');
+    });
+  });
+
+  return workers;
 }
 
 export async function stopWorkers(workers: Worker[]): Promise<void> {
-  throw new Error('Not implemented: stopWorkers');
+  await Promise.all(workers.map(worker => worker.close()));
+  await closeQueues();
 }
 
 // Standalone worker entry point


### PR DESCRIPTION
## Summary

Implement background job queue management functions for the Bull MQ job processor.

## Changes

- **#436**: Implement `enqueuePipelineMetrics()` to add jobs to asyncPipeline queue
- **#437**: Implement `enqueueWebhookRetry()` to add retry jobs to webhookRetry queue
- **#438**: Implement `getQueueWaitingCount()` to get waiting job counts in async queues
- **#439**: Implement `startWorkers()` to create worker instances for all job processors

## Implementation Details

### Queue Functions (queue.ts)
- `enqueuePipelineMetrics()`: Enqueues pipeline metrics jobs to asyncPipeline queue
- `enqueueWebhookRetry()`: Enqueues webhook retry jobs to webhookRetry queue
- `getQueueWaitingCount()`: Returns count of waiting jobs in specified queue
- `getAllQueues()`: Helper to get all queue instances
- `closeQueues()`: Helper to close all queue connections

### Worker Functions (worker.ts)
- `startWorkers()`: Creates worker instances for each job processor type with configured concurrency levels
- `stopWorkers()`: Gracefully closes all workers and queue connections

Closes #436
Closes #437
Closes #438
Closes #439