### PR TITLE
feat(api): implement verifyAuditChain, cacheGet, getPoolMetrics, invalidateHealthCache

### DIFF
--- a/api/src/services/auditLog.ts
+++ b/api/src/services/auditLog.ts
@@ -74,14 +74,71 @@ function cloneCheckpoint(checkpoint: AuditCheckpoint): AuditCheckpoint {
 }
 
 export function hashPayload(payload: unknown): string {
-  throw new Error('Not implemented: hashPayload');
+  return sha256(stableStringify(payload));
 }
 
 export function verifyAuditChain(
   entries: AuditLogEntry[],
   checkpoints: AuditCheckpoint[] = [],
 ): AuditVerificationResult {
-  throw new Error('Not implemented: verifyAuditChain');
+  const errors: Array<{ sequence?: number; message: string }> = [];
+
+  // Build a map of checkpoints by sequence for O(1) lookup
+  const checkpointMap = new Map<number, AuditCheckpoint>();
+  for (const cp of checkpoints) {
+    checkpointMap.set(cp.sequence, cp);
+  }
+
+  let expectedPreviousHash = GENESIS_HASH;
+
+  for (const entry of entries) {
+    // 1. Verify the previousHash links correctly to the prior entry
+    if (entry.previousHash !== expectedPreviousHash) {
+      errors.push({
+        sequence: entry.sequence,
+        message: 'broken chain link',
+      });
+    }
+
+    // 2. Recompute the entry's hash and compare
+    const recomputed = sha256(
+      entryHashMaterial({
+        sequence: entry.sequence,
+        id: entry.id,
+        timestamp: entry.timestamp,
+        type: entry.type,
+        actor: entry.actor,
+        payload: entry.payload,
+        previousHash: entry.previousHash,
+        retentionUntil: entry.retentionUntil,
+      }),
+    );
+
+    if (recomputed !== entry.hash) {
+      errors.push({
+        sequence: entry.sequence,
+        message: 'entry hash mismatch',
+      });
+    }
+
+    // 3. Verify checkpoint for this sequence, if one exists
+    const checkpoint = checkpointMap.get(entry.sequence);
+    if (checkpoint && checkpoint.hash !== recomputed) {
+      errors.push({
+        sequence: entry.sequence,
+        message: 'checkpoint hash does not match recomputed entry hash',
+      });
+    }
+
+    expectedPreviousHash = entry.hash;
+  }
+
+  return {
+    valid: errors.length === 0,
+    entryCount: entries.length,
+    checkpointCount: checkpoints.length,
+    errors,
+  };
 }
 
 export class IntegrityAuditLogService {

--- a/api/src/services/cache.ts
+++ b/api/src/services/cache.ts
@@ -40,7 +40,7 @@ export const SWR_EXTENSION_SECONDS = 5;
  * Format: `v{version}:{namespace}:{discriminator}`
  */
 export function buildCacheKey(namespace: string, discriminator: string): string {
-  throw new Error('Not implemented: buildCacheKey');
+  return `v${CACHE_VERSION}:${namespace}:${discriminator}`;
 }
 
 // ─── Redis singleton ─────────────────────────────────────────────────────────
@@ -138,19 +138,59 @@ export interface CacheMetrics {
 }
 
 export async function cacheGet(key: string): Promise<string | null> {
-  throw new Error('Not implemented: cacheGet');
+  const redis = getClient();
+  if (!redis) return null;
+
+  startMetricsSampler();
+
+  try {
+    const value = await redis.get(key);
+    if (value === null) {
+      recordMiss();
+      return null;
+    }
+    recordHit();
+    return value;
+  } catch {
+    recordMiss();
+    return null;
+  }
 }
 
 export async function cacheSet(key: string, value: string, ttlSeconds: number): Promise<void> {
-  throw new Error('Not implemented: cacheSet');
+  const redis = getClient();
+  if (!redis) return;
+
+  try {
+    await redis.set(key, value, 'EX', ttlSeconds);
+  } catch {
+    // Gracefully degrade — callers fall back to live queries.
+  }
 }
 
 export async function cacheDel(key: string): Promise<void> {
-  throw new Error('Not implemented: cacheDel');
+  const redis = getClient();
+  if (!redis) return;
+
+  try {
+    await redis.del(key);
+  } catch {
+    // Gracefully degrade.
+  }
 }
 
 export async function cacheDelPattern(pattern: string): Promise<void> {
-  throw new Error('Not implemented: cacheDelPattern');
+  const redis = getClient();
+  if (!redis) return;
+
+  try {
+    const keys = await redis.keys(pattern);
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+  } catch {
+    // Gracefully degrade.
+  }
 }
 
 // ─── Stale-while-revalidate ──────────────────────────────────────────────────
@@ -201,7 +241,19 @@ export async function swrGet<T>(key: string): Promise<{ value: T; stale: boolean
  * data is still available during background revalidation.
  */
 export async function swrSet<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
-  throw new Error('Not implemented: swrSet');
+  const redis = getClient();
+  if (!redis) return;
+
+  const entry: SWREntry<T> = {
+    value,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  };
+
+  try {
+    await redis.set(key, JSON.stringify(entry), 'EX', ttlSeconds + SWR_EXTENSION_SECONDS);
+  } catch {
+    // Gracefully degrade.
+  }
 }
 
 // ─── Single-flight / stampede protection ─────────────────────────────────────
@@ -250,7 +302,29 @@ export async function withSingleFlight<T>(
   fn: () => Promise<T>,
   lockTtlMs = 5000,
 ): Promise<T> {
-  throw new Error('Not implemented: withSingleFlight');
+  // Layer 1: in-process deduplication — check before storing
+  const existing = inFlightMap.get(key);
+  if (existing) {
+    return existing as Promise<T>;
+  }
+
+  // Create the promise immediately (synchronously) and store it before
+  // yielding control, so concurrent callers see it in the map.
+  const lockKey = `lock:${key}`;
+
+  const promise = (async () => {
+    // Layer 2: acquire Redis lock (best-effort; falls through if Redis unavailable)
+    await acquireRedisLock(lockKey, lockTtlMs);
+    try {
+      return await fn();
+    } finally {
+      inFlightMap.delete(key);
+      void releaseRedisLock(lockKey);
+    }
+  })();
+
+  inFlightMap.set(key, promise as Promise<string | null>);
+  return promise;
 }
 
 // ─── Combined get-or-compute (the main high-level helper) ─────────────────────

--- a/api/src/services/db.ts
+++ b/api/src/services/db.ts
@@ -4,10 +4,25 @@ import { config } from '../config';
 import { logger } from '../logger';
 import { register } from './metrics';
 
-const pool: Pool | null = null;
+let _pool: Pool | null = null;
 
 export function getPool(): Pool | null {
-  throw new Error('Not implemented: getPool');
+  if (!config.database.url) return null;
+  if (_pool) return _pool;
+
+  _pool = new Pool({
+    connectionString: config.database.url,
+    max: config.database.poolMax,
+    idleTimeoutMillis: config.database.idleTimeoutMs,
+    connectionTimeoutMillis: config.database.connectionTimeoutMs,
+    ssl: config.database.ssl ? { rejectUnauthorized: false } : false,
+  });
+
+  _pool.on('error', (err) => {
+    logger.error({ err }, 'Unexpected error on idle PostgreSQL client');
+  });
+
+  return _pool;
 }
 
 export interface PoolMetrics {
@@ -23,7 +38,17 @@ export interface PoolMetrics {
 
 /** Live snapshot of the PostgreSQL pool, or null when the DB is not configured. */
 export function getPoolMetrics(): PoolMetrics | null {
-  throw new Error('Not implemented: getPoolMetrics');
+  const p = getPool();
+  if (!p) return null;
+
+  const idle = p.idleCount;
+  const active = p.totalCount - p.idleCount;
+  return {
+    total: p.totalCount,
+    idle,
+    active,
+    waiting: p.waitingCount,
+  };
 }
 
 // ─── Pool metrics ──────────────────────────────────────────────────────────────
@@ -80,5 +105,8 @@ export async function dbHealthCheck(): Promise<{ ok: boolean; latencyMs?: number
 }
 
 export async function closePool(): Promise<void> {
-  throw new Error('Not implemented: closePool');
+  if (_pool) {
+    await _pool.end();
+    _pool = null;
+  }
 }

--- a/api/src/services/health.ts
+++ b/api/src/services/health.ts
@@ -58,9 +58,53 @@ async function checkRedis(): Promise<DependencyCheck> {
 }
 
 export async function getHealthStatus(force = false): Promise<HealthResult> {
-  throw new Error('Not implemented: getHealthStatus');
+  const now = Date.now();
+
+  // Return cached result if still valid and not forced
+  if (!force && cachedResult !== null && now < cacheExpiresAt) {
+    return cachedResult;
+  }
+
+  // Run all dependency checks in parallel
+  const [sorobanResult, redisResult, dbResult] = await Promise.all([
+    checkSoroban(),
+    checkRedis(),
+    dbHealthCheck(),
+  ]);
+
+  const dependencies: HealthResult['dependencies'] = {
+    soroban: { ...sorobanResult, critical: true },
+    redis: { ...redisResult, critical: false },
+    database: { ...dbResult, critical: false },
+  };
+
+  // Determine overall status
+  let status: HealthResult['status'] = 'ok';
+  for (const [, dep] of Object.entries(dependencies)) {
+    if (!dep.ok) {
+      if (dep.critical) {
+        status = 'unhealthy';
+        break;
+      } else {
+        status = 'degraded';
+      }
+    }
+  }
+
+  const result: HealthResult = {
+    status,
+    timestamp: now,
+    version: config.logging.version,
+    dependencies,
+  };
+
+  cachedResult = result;
+  cacheExpiresAt = now + CACHE_TTL_MS;
+
+  return result;
 }
 
 export function invalidateHealthCache(): void {
-  throw new Error('Not implemented: invalidateHealthCache');
+  cachedResult = null;
+  cacheExpiresAt = 0;
 }


### PR DESCRIPTION
## Summary

Implements four stubbed service functions across three files.

### Changes

- **`api/src/services/auditLog.ts`** — `verifyAuditChain` (#488): iterates entries, checks `previousHash` chain links, recomputes each SHA-256 hash, detects tampering against checkpoints. Also implements `hashPayload`.
- **`api/src/services/cache.ts`** — `cacheGet` and related helpers (#489): `buildCacheKey`, `cacheGet`, `cacheSet`, `cacheDel`, `cacheDelPattern`, `swrSet`, `withSingleFlight`. Includes graceful Redis degradation, hit/miss tracking, SWR entry storage, and in-process + Redis SETNX stampede protection.
- **`api/src/services/db.ts`** — `getPoolMetrics` and related helpers (#490): lazy `getPool` initialization when `DATABASE_URL` is set, live snapshot of `total/idle/active/waiting` pool connections, `closePool` teardown.
- **`api/src/services/health.ts`** — `invalidateHealthCache` and `getHealthStatus` (#491): parallel dependency checks (soroban=critical, redis+db=non-critical), 5s result caching, proper `ok/degraded/unhealthy` status logic.

## Tests

| File | Result |
|------|--------|
| `cache.test.ts` | 26/26 pass |
| `db.test.ts` | 3/3 pass |
| `health.test.ts` | 5/5 pass |
| `auditLog.test.ts` | Blocked by pre-existing `requireScopes` stub (separate issue, not in scope) |

Only the 4 target service files are modified in this PR.

Closes #488
Closes #489
Closes #490
Closes #491