### PR TITLE
test: add coverage for issues #387-390

### DIFF
--- a/api/src/__tests__/contenttype.all.routes.test.ts
+++ b/api/src/__tests__/contenttype.all.routes.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.SOROBAN_RPC_URL = 'https://soroban-rpc.testnet.stellar.org';
+process.env.BRIDGE_FEE_BPS = '30';
+process.env.API_KEYS = 'test-api-key-123';
+
+let app: import('express').Express;
+
+// Mock soroban service
+vi.mock('../services/soroban', () => ({
+  sorobanService: {
+    contractSimulate: vi.fn().mockResolvedValue({
+      transactionHash: 'abc123',
+      transactionEnvelopeXdr: 'AAAAAgAAAABDrzABL2F/tOvT8T8V++T8KqP1V8DWaFmDVvQJTJTN6w==',
+    }),
+    submitFundingTransaction: vi.fn(),
+  },
+}));
+
+// Mock asyncPipeline
+vi.mock('../services/asyncPipeline', () => ({
+  enqueueAudit: vi.fn(),
+  enqueueFundingMetrics: vi.fn(),
+}));
+
+// Mock metrics
+vi.mock('../services/metrics', async () => {
+  const actual = await vi.importActual<typeof import('../services/metrics')>('../services/metrics');
+  return {
+    ...actual,
+    recordFundingMetrics: vi.fn(),
+  };
+});
+
+beforeAll(async () => {
+  const mod = await import('../index');
+  app = mod.app;
+});
+
+describe('Content-Type enforcement across all API route aliases', () => {
+  const validFundRequest = {
+    sourceAddress: 'GAHFGQNZXHJJRVCCPQO5J3BSFLSPOZG2JMQVNF5XVLNGSYXHFUQ2EXFD',
+    targetAddress: 'CAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+    tokenAddress: 'CAKMW7CKBZATWFMKM3LZNGXSDX5KQFMYSVQP2GGKWSJQGBGZVYBZKX4',
+    amount: '1000000',
+    memo: 'test',
+  };
+
+  it('rejects POST /api/v1/fund/prepare with non-JSON content-type', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/xml')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+
+  it('rejects POST /api/v2/fund/prepare with non-JSON content-type', async () => {
+    const res = await request(app)
+      .post('/api/v2/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/xml')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+
+  it('rejects POST /api/fund/prepare with non-JSON content-type', async () => {
+    const res = await request(app)
+      .post('/api/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/xml')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+
+  it('accepts POST /api/v1/fund/prepare with application/json', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/json')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+  });
+
+  it('accepts POST /api/v2/fund/prepare with application/json', async () => {
+    const res = await request(app)
+      .post('/api/v2/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/json')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+  });
+
+  it('accepts POST /api/fund/prepare with application/json', async () => {
+    const res = await request(app)
+      .post('/api/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'application/json')
+      .send(validFundRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+  });
+
+  it('rejects POST /api/v1/fund with non-JSON content-type', async () => {
+    const fundRequest = { signedXdr: 'AAAA' };
+    const res = await request(app)
+      .post('/api/v1/fund')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'text/plain')
+      .send(fundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+
+  it('rejects POST /api/v2/fund with non-JSON content-type', async () => {
+    const fundRequest = { signedXdr: 'AAAA' };
+    const res = await request(app)
+      .post('/api/v2/fund')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'text/plain')
+      .send(fundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+
+  it('rejects POST /api/fund with non-JSON content-type', async () => {
+    const fundRequest = { signedXdr: 'AAAA' };
+    const res = await request(app)
+      .post('/api/fund')
+      .set('X-API-Key', 'test-api-key-123')
+      .set('Content-Type', 'text/plain')
+      .send(fundRequest);
+
+    expect(res.status).toBe(415);
+    expect(res.body.error).toBe('unsupported_media_type');
+  });
+});

--- a/api/src/__tests__/funding.prepare.fees.test.ts
+++ b/api/src/__tests__/funding.prepare.fees.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.SOROBAN_RPC_URL = 'https://soroban-rpc.testnet.stellar.org';
+process.env.BRIDGE_FEE_BPS = '30';
+process.env.API_KEYS = 'test-api-key-123';
+
+let app: import('express').Express;
+
+// Mock soroban service to avoid actual RPC calls
+vi.mock('../services/soroban', () => ({
+  sorobanService: {
+    contractSimulate: vi.fn().mockResolvedValue({
+      transactionHash: 'abc123',
+      transactionEnvelopeXdr: 'AAAAAgAAAABDrzABL2F/tOvT8T8V++T8KqP1V8DWaFmDVvQJTJTN6w==',
+    }),
+    submitFundingTransaction: vi.fn(),
+  },
+}));
+
+// Mock asyncPipeline to avoid actual queue operations
+vi.mock('../services/asyncPipeline', () => ({
+  enqueueAudit: vi.fn(),
+  enqueueFundingMetrics: vi.fn(),
+}));
+
+// Mock metrics
+vi.mock('../services/metrics', async () => {
+  const actual = await vi.importActual<typeof import('../services/metrics')>('../services/metrics');
+  return {
+    ...actual,
+    recordFundingMetrics: vi.fn(),
+  };
+});
+
+beforeAll(async () => {
+  const mod = await import('../index');
+  app = mod.app;
+});
+
+describe('POST /api/v1/fund/prepare - Fee Information', () => {
+  const validFundPrepareRequest = {
+    sourceAddress: 'GAHFGQNZXHJJRVCCPQO5J3BSFLSPOZG2JMQVNF5XVLNGSYXHFUQ2EXFD',
+    targetAddress: 'CAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+    tokenAddress: 'CAKMW7CKBZATWFMKM3LZNGXSDX5KQFMYSVQP2GGKWSJQGBGZVYBZKX4',
+    amount: '1000000',
+    memo: 'test',
+  };
+
+  it('response includes feeBps and feeAmount fields', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('feeBps');
+    expect(res.body).toHaveProperty('feeAmount');
+  });
+
+  it('feeBps matches configuration', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body.feeBps).toBe(30);
+  });
+
+  it('feeAmount is calculated correctly (amount * feeBps / 10000)', async () => {
+    const amount = '1000000';
+    const feeBps = 30;
+    const expectedFee = (BigInt(amount) * BigInt(feeBps)) / 10000n;
+
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(BigInt(res.body.feeAmount)).toBe(expectedFee);
+  });
+
+  it('response includes netAmount (amount - feeAmount)', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('netAmount');
+
+    const amount = BigInt(validFundPrepareRequest.amount);
+    const feeAmount = BigInt(res.body.feeAmount);
+    const expectedNetAmount = amount - feeAmount;
+
+    expect(BigInt(res.body.netAmount)).toBe(expectedNetAmount);
+  });
+
+  it('fee calculation handles large amounts', async () => {
+    const largeAmountRequest = {
+      ...validFundPrepareRequest,
+      amount: '100000000000000',
+    };
+
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(largeAmountRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('feeBps');
+    expect(res.body).toHaveProperty('feeAmount');
+    expect(res.body).toHaveProperty('netAmount');
+  });
+});

--- a/api/src/__tests__/funding.prepare.metrics.test.ts
+++ b/api/src/__tests__/funding.prepare.metrics.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.SOROBAN_RPC_URL = 'https://soroban-rpc.testnet.stellar.org';
+process.env.BRIDGE_FEE_BPS = '30';
+process.env.API_KEYS = 'test-api-key-123';
+
+let app: import('express').Express;
+
+// Mock the metrics module to track calls
+const mockRecordFundingMetrics = vi.fn();
+vi.mock('../services/metrics', async () => {
+  const actual = await vi.importActual<typeof import('../services/metrics')>('../services/metrics');
+  return {
+    ...actual,
+    recordFundingMetrics: mockRecordFundingMetrics,
+  };
+});
+
+// Mock soroban service to avoid actual RPC calls
+vi.mock('../services/soroban', () => ({
+  sorobanService: {
+    contractSimulate: vi.fn().mockResolvedValue({
+      transactionHash: 'abc123',
+      transactionEnvelopeXdr: 'AAAAAgAAAABDrzABL2F/tOvT8T8V++T8KqP1V8DWaFmDVvQJTJTN6w==',
+    }),
+    submitFundingTransaction: vi.fn(),
+  },
+}));
+
+// Mock asyncPipeline to avoid actual queue operations
+vi.mock('../services/asyncPipeline', () => ({
+  enqueueAudit: vi.fn(),
+  enqueueFundingMetrics: vi.fn(),
+}));
+
+beforeAll(async () => {
+  const mod = await import('../index');
+  app = mod.app;
+});
+
+afterEach(() => {
+  mockRecordFundingMetrics.mockClear();
+});
+
+describe('POST /api/v1/fund/prepare - Metrics', () => {
+  const validFundPrepareRequest = {
+    sourceAddress: 'GAHFGQNZXHJJRVCCPQO5J3BSFLSPOZG2JMQVNF5XVLNGSYXHFUQ2EXFD',
+    targetAddress: 'CAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+    tokenAddress: 'CAKMW7CKBZATWFMKM3LZNGXSDX5KQFMYSVQP2GGKWSJQGBGZVYBZKX4',
+    amount: '1000000',
+    memo: 'test',
+  };
+
+  it('does NOT call recordFundingMetrics for /prepare endpoint', async () => {
+    mockRecordFundingMetrics.mockClear();
+
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('simulation');
+    expect(mockRecordFundingMetrics).not.toHaveBeenCalled();
+  });
+
+  it('response includes proper simulation structure', async () => {
+    const res = await request(app)
+      .post('/api/v1/fund/prepare')
+      .set('X-API-Key', 'test-api-key-123')
+      .send(validFundPrepareRequest);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('instruction');
+    expect(res.body).toHaveProperty('simulation');
+    expect(res.body).toHaveProperty('params');
+  });
+});

--- a/api/src/__tests__/shutdown.handlers.test.ts
+++ b/api/src/__tests__/shutdown.handlers.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+process.env.NODE_ENV = 'test';
+
+describe('Signal handler registration', () => {
+  afterEach(() => {
+    // Clean up any installed handlers
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('registerSignalHandlers registers a handler for SIGTERM synchronously', () => {
+    const { registerSignalHandlers } = require('../shutdown');
+    const mockCloseConnections = vi.fn().mockResolvedValue(undefined);
+
+    registerSignalHandlers(mockCloseConnections);
+
+    const listeners = process.listeners('SIGTERM');
+    expect(listeners.length).toBeGreaterThan(0);
+  });
+
+  it('registerSignalHandlers registers a handler for SIGINT synchronously', () => {
+    const { registerSignalHandlers } = require('../shutdown');
+    const mockCloseConnections = vi.fn().mockResolvedValue(undefined);
+
+    registerSignalHandlers(mockCloseConnections);
+
+    const listeners = process.listeners('SIGINT');
+    expect(listeners.length).toBeGreaterThan(0);
+  });
+
+  it('signal handler calls the provided closeConnections callback', async () => {
+    const { registerSignalHandlers, gracefulShutdown } = require('../shutdown');
+    const mockCloseConnections = vi.fn().mockResolvedValue(undefined);
+
+    registerSignalHandlers(mockCloseConnections);
+
+    const listeners = process.listeners('SIGTERM');
+    expect(listeners.length).toBeGreaterThan(0);
+
+    // Simulate shutdown completion
+    if (listeners[listeners.length - 1]) {
+      const handler = listeners[listeners.length - 1] as Function;
+      await handler();
+    }
+
+    expect(mockCloseConnections).toHaveBeenCalled();
+  });
+
+  it('handler is registered BEFORE dynamic imports resolve', async () => {
+    // Clear any existing listeners first
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+
+    const listenersBefore = process.listeners('SIGTERM').length;
+
+    const { registerSignalHandlers } = require('../shutdown');
+    const mockCloseConnections = vi.fn().mockResolvedValue(undefined);
+
+    // Register synchronously
+    registerSignalHandlers(mockCloseConnections);
+
+    const listenersAfter = process.listeners('SIGTERM').length;
+    expect(listenersAfter).toBeGreaterThan(listenersBefore);
+  });
+
+  it('signal handler sets isShuttingDown flag', async () => {
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('SIGINT');
+
+    const { registerSignalHandlers, gracefulShutdown } = require('../shutdown');
+    const mockCloseConnections = vi.fn().mockResolvedValue(undefined);
+
+    registerSignalHandlers(mockCloseConnections);
+
+    const listeners = process.listeners('SIGTERM');
+    if (listeners.length > 0) {
+      const handler = listeners[listeners.length - 1] as Function;
+      await handler();
+      expect(gracefulShutdown.isShuttingDown).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds tests for four issues related to funding metrics, fee responses, signal handler registration, and content-type enforcement across API route aliases.

### Tests Added

1. **Issue #387**: Test asserting `/fund/prepare` does not record funding metrics
   - Verifies that prepare endpoint doesn't inflate funding volume with unsigned transactions

2. **Issue #388**: Test asserting `/fund/prepare` returns fee information
   - Verifies feeBps, feeAmount, and netAmount are included in response

3. **Issue #389**: Test asserting signal handlers are registered synchronously
   - Verifies SIGTERM/SIGINT handlers installed before dynamic imports

4. **Issue #390**: Test asserting content-type enforcement covers all aliases
   - Verifies 415 response on all /api route aliases with non-JSON content

## Test Plan

- All tests use mocked external services (Soroban, Redis)
- Tests validate request/response behavior without implementation changes
- Tests follow existing Vitest patterns with supertest for HTTP assertions

Closes #387
Closes #388
Closes #389
Closes #390