### PR TITLE
feat: implement tierRateLimitMiddleware, isCAddress, isSacToken

### DIFF
--- a/api/src/middleware/rateLimit.ts
+++ b/api/src/middleware/rateLimit.ts
@@ -106,7 +106,8 @@ export const ipRateLimitMiddleware = (req: Request, res: Response, next: NextFun
 
 /** Per-API-key tier rate limit — applied after RBAC on protected routes. */
 export function tierRateLimitMiddleware(req: Request, res: Response, next: NextFunction) {
-  throw new Error('Not implemented: tierRateLimitMiddleware');
+  const tier = resolveTier(req);
+  tierLimiters[tier](req, res, next);
 }
 
 /** Fund endpoint rate limit — 10 req/min per API key or IP. */

--- a/sdk/src/token.ts
+++ b/sdk/src/token.ts
@@ -10,7 +10,7 @@ export function isNativeToken(token: Token): token is { type: 'native' } {
 
 /** Returns `true` if the token is a SAC (Stellar Asset Converter) token. */
 export function isSacToken(token: Token): token is { type: 'sac'; contractId: string } {
-  throw new Error('Not implemented: isSacToken');
+  return token.type === 'sac';
 }
 
 // ─── Address Validation ───────────────────────────────────────────────────────

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -11,7 +11,7 @@ export function isValidStellarAddress(address: string): boolean {
 
 /** Returns `true` if the address is a Soroban contract address (starts with `C`). */
 export function isCAddress(address: string): boolean {
-  throw new Error('Not implemented: isCAddress');
+  return typeof address === 'string' && address.startsWith('C');
 }
 
 /** Returns `true` if the address is a classic Stellar account address (starts with `G`). */


### PR DESCRIPTION
Implements the bodies of three previously stubbed functions and acknowledges the already-implemented cleanup processor.

## Changes

- **tierRateLimitMiddleware** (`api/src/middleware/rateLimit.ts`): Resolves API key tier via `resolveTier()` and delegates to the matching pre-built tier limiter.
- **isCAddress** (`sdk/src/utils.ts`): Returns `true` if the address starts with `C` (Soroban contract address).
- **isSacToken** (`sdk/src/token.ts`): Type guard that returns `true` when `token.type === 'sac'`.
- **processCleanup** (`api/src/jobs/processors/cleanup.ts`): Already implemented — no changes needed.

Closes #503
Closes #502
Closes #499
Closes #498